### PR TITLE
Handle executor verification albums

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -76,6 +76,34 @@ const cloneUploadedPhotos = (
   return photos.map((photo) => ({ ...photo }));
 };
 
+const cloneProcessedMediaGroups = (
+  groups?: ExecutorVerificationRoleState['processedMediaGroups'],
+): ExecutorVerificationRoleState['processedMediaGroups'] => {
+  if (!groups || typeof groups !== 'object') {
+    return {};
+  }
+
+  const clone: ExecutorVerificationRoleState['processedMediaGroups'] = {};
+  for (const [key, value] of Object.entries(groups)) {
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+
+    const progressNotified = Boolean((value as { progressNotified?: unknown }).progressNotified);
+    const sourceIds = (value as { photoUniqueIds?: unknown }).photoUniqueIds;
+    const photoUniqueIds = Array.isArray(sourceIds)
+      ? sourceIds.filter((id): id is string => typeof id === 'string')
+      : [];
+
+    clone[key] = {
+      photoUniqueIds: [...photoUniqueIds],
+      progressNotified,
+    };
+  }
+
+  return clone;
+};
+
 const cloneModerationState = (
   moderation?: ExecutorVerificationRoleState['moderation'],
 ): ExecutorVerificationRoleState['moderation'] => {
@@ -93,6 +121,7 @@ const createRoleVerificationState = (): ExecutorVerificationRoleState => ({
   submittedAt: undefined,
   moderation: undefined,
   lastReminderAt: undefined,
+  processedMediaGroups: {},
 });
 
 const createSubscriptionState = (): ExecutorSubscriptionState => ({
@@ -114,6 +143,7 @@ const normaliseRoleVerificationState = (
   submittedAt: value?.submittedAt,
   moderation: cloneModerationState(value?.moderation),
   lastReminderAt: typeof value?.lastReminderAt === 'number' ? value.lastReminderAt : undefined,
+  processedMediaGroups: cloneProcessedMediaGroups(value?.processedMediaGroups),
 });
 
 const createDefaultVerificationState = () => {
@@ -156,6 +186,7 @@ const normaliseVerificationState = (
     verification[role] = {
       ...fallback,
       uploadedPhotos: cloneUploadedPhotos(fallback.uploadedPhotos),
+      processedMediaGroups: cloneProcessedMediaGroups(fallback.processedMediaGroups),
     };
   }
 

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -111,6 +111,11 @@ export interface ExecutorUploadedPhoto {
   fileUniqueId?: string;
 }
 
+export interface ExecutorVerificationMediaGroupProgress {
+  photoUniqueIds: string[];
+  progressNotified: boolean;
+}
+
 export type ExecutorVerificationStatus = 'idle' | 'collecting' | 'submitted';
 
 export interface ExecutorVerificationModerationState {
@@ -127,6 +132,7 @@ export interface ExecutorVerificationRoleState {
   submittedAt?: number;
   moderation?: ExecutorVerificationModerationState;
   lastReminderAt?: number;
+  processedMediaGroups: Record<string, ExecutorVerificationMediaGroupProgress>;
 }
 
 export type ExecutorSubscriptionStatus =

--- a/tests/executor-verification-album.test.js
+++ b/tests/executor-verification-album.test.js
@@ -1,0 +1,125 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+const ensureEnv = (key, value) => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+ensureEnv('BOT_TOKEN', 'test-bot-token');
+ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+ensureEnv('KASPI_NAME', 'Test User');
+ensureEnv('KASPI_PHONE', '+70000000000');
+ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+ensureEnv('WEBHOOK_SECRET', 'secret');
+
+const { ui } = require('../src/bot/ui');
+const menu = require('../src/bot/flows/executor/menu');
+const verificationFlow = require('../src/bot/flows/executor/verification');
+
+const createPhotoMessage = (messageId, fileId, uniqueId) => ({
+  message_id: messageId,
+  date: 1,
+  media_group_id: 'album-1',
+  chat: { id: 999, type: 'private' },
+  photo: [
+    { file_id: `${fileId}-preview`, file_unique_id: `${uniqueId}-preview`, width: 90, height: 90 },
+    { file_id: fileId, file_unique_id: uniqueId, width: 1280, height: 960 },
+  ],
+});
+
+test('handleIncomingPhoto processes album photos once', { concurrency: false }, async (t) => {
+  const progressSteps = [];
+  const originalUiStep = ui.step;
+  ui.step = async (_ctx, options) => {
+    progressSteps.push(options);
+    return { messageId: progressSteps.length, sent: true };
+  };
+  t.after(() => {
+    ui.step = originalUiStep;
+  });
+
+  const ctx = {
+    chat: { id: 999, type: 'private' },
+    session: {
+      executor: undefined,
+      ui: { steps: {}, homeActions: [], pendingCityAction: undefined },
+      city: 'almaty',
+    },
+    reply: async () => {},
+    auth: {
+      user: {
+        telegramId: undefined,
+        username: 'courieruser',
+        firstName: 'Courier',
+        lastName: 'User',
+        role: 'executor',
+        executorKind: 'courier',
+        status: 'active_executor',
+        phoneVerified: true,
+        verifyStatus: 'none',
+        subscriptionStatus: 'none',
+        isVerified: false,
+        isBlocked: false,
+        hasActiveOrder: false,
+        citySelected: 'almaty',
+      },
+      executor: {
+        verifiedRoles: { courier: false, driver: false },
+        hasActiveSubscription: false,
+        isVerified: false,
+      },
+      isModerator: false,
+    },
+    telegram: {},
+  };
+
+  const state = menu.ensureExecutorState(ctx);
+  state.role = 'courier';
+  state.verification.courier.status = 'collecting';
+  state.verification.courier.uploadedPhotos = [];
+  state.verification.courier.processedMediaGroups = {};
+
+  const albumMessages = [
+    createPhotoMessage(201, 'photo-1', 'unique-1'),
+    createPhotoMessage(202, 'photo-2', 'unique-2'),
+    createPhotoMessage(203, 'photo-3', 'unique-3'),
+  ];
+
+  const { handleIncomingPhoto } = verificationFlow.__private__;
+
+  for (const message of albumMessages) {
+    ctx.message = message;
+    const handled = await handleIncomingPhoto(ctx, message);
+    assert.equal(handled, true, 'photo message should be handled');
+  }
+
+  const verificationState = ctx.session.executor.verification.courier;
+
+  assert.equal(
+    verificationState.uploadedPhotos.length,
+    3,
+    'three unique photos from the album should be stored',
+  );
+
+  const albumState = verificationState.processedMediaGroups['album-1'];
+  assert.ok(albumState, 'album state should be tracked');
+  assert.deepEqual(
+    albumState.photoUniqueIds.sort(),
+    ['unique-1', 'unique-2', 'unique-3'],
+    'all album photos should be tracked by unique id',
+  );
+
+  const progressMessages = progressSteps.filter(
+    (step) => step.id === 'executor:verification:progress',
+  );
+  assert.equal(progressMessages.length, 1, 'progress should be reported once for the album');
+  assert.ok(
+    progressMessages[0].text.includes('Фото 3/3 получено'),
+    'progress message should reflect three uploaded photos',
+  );
+});


### PR DESCRIPTION
## Summary
- track processed media groups in executor verification state so album photos are deduplicated
- update the verification photo handler to aggregate album uploads and only emit one progress update per media group
- add a regression test that feeds album updates and verifies three photos are counted

## Testing
- node --test tests/executor-verification-album.test.js

------
https://chatgpt.com/codex/tasks/task_e_68da01aaf398832d8c804d8e7e4285e0