### PR TITLE
Handle executor verification continuation on start

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -190,6 +190,22 @@ export const handleStart = async (ctx: BotContext): Promise<void> => {
   const needsRoleSelection =
     !role || awaitingRoleSelection || stage === 'role' || stage === 'executorKind' || stage === 'city';
   if (needsRoleSelection) {
+    const verificationRoleState = role ? executorState.verification[role] : undefined;
+    const hasUnfinishedVerification =
+      Boolean(
+        role &&
+          verificationRoleState &&
+          (verificationRoleState.status === 'collecting' ||
+            verificationRoleState.uploadedPhotos.length > 0),
+      );
+
+    if (hasUnfinishedVerification) {
+      executorState.awaitingRoleSelection = false;
+      executorState.roleSelectionStage = undefined;
+      await startExecutorVerification(ctx);
+      return;
+    }
+
     executorState.awaitingRoleSelection = true;
     executorState.role = undefined;
     const prompt = stage === 'executorKind' || stage === 'city'

--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -273,17 +273,24 @@ export const ensureExecutorState = (ctx: BotContext): ExecutorFlowState => {
     const hasActiveRoleSelectionStage = state.roleSelectionStage !== undefined;
     if (hasActiveRoleSelectionStage && state.awaitingRoleSelection !== true) {
       state.awaitingRoleSelection = true;
+    } else if (
+      derivedRole !== undefined &&
+      !hasActiveRoleSelectionStage &&
+      state.awaitingRoleSelection === true
+    ) {
+      state.awaitingRoleSelection = false;
     }
 
     const awaitingSelection = state.awaitingRoleSelection === true;
 
     if (derivedRole !== undefined) {
-      if (!awaitingSelection) {
+      if (!state.role) {
         state.role = derivedRole;
+      }
+
+      if (!awaitingSelection) {
         state.awaitingRoleSelection = false;
         state.roleSelectionStage = undefined;
-      } else if (!state.role) {
-        state.role = derivedRole;
       }
     } else if (ctx.session.isAuthenticated === false && ctx.auth.user.role === 'guest') {
       // Preserve the existing executor role when auth falls back to the guest context.

--- a/tests/start-executor-verification.test.js
+++ b/tests/start-executor-verification.test.js
@@ -1,0 +1,133 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+const ensureEnv = (key, value) => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+ensureEnv('BOT_TOKEN', 'test-bot-token');
+ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+ensureEnv('KASPI_NAME', 'Test User');
+ensureEnv('KASPI_PHONE', '+70000000000');
+ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+ensureEnv('WEBHOOK_SECRET', 'secret');
+
+const uiModule = require('../src/bot/ui');
+const commandsModule = require('../src/bot/services/commands');
+const clientMenuModule = require('../src/ui/clientMenu');
+const menuModule = require('../src/bot/flows/executor/menu');
+const verificationModule = require('../src/bot/flows/executor/verification');
+
+const createTestContext = () => {
+  const ctx = {
+    chat: { id: 4242, type: 'private' },
+    from: { id: 4242 },
+    auth: {
+      user: {
+        telegramId: 4242,
+        phoneVerified: true,
+        role: 'executor',
+        executorKind: 'courier',
+        status: 'active_executor',
+        verifyStatus: 'pending',
+        subscriptionStatus: 'none',
+        isVerified: false,
+        isBlocked: false,
+        hasActiveOrder: false,
+        citySelected: 'almaty',
+      },
+      executor: {
+        verifiedRoles: { courier: false, driver: false },
+        hasActiveSubscription: false,
+        isVerified: false,
+      },
+      isModerator: false,
+    },
+    session: {
+      user: { phoneVerified: true },
+      isAuthenticated: true,
+      ui: {
+        steps: {},
+        homeActions: [],
+        pendingCityAction: undefined,
+        clientMenuVariant: undefined,
+      },
+    },
+    telegram: {
+      sendMessage: async () => ({ message_id: 1001 }),
+      editMessageText: async () => ({ message_id: 1001 }),
+      deleteMessage: async () => undefined,
+      setMyCommands: async () => undefined,
+      setChatMenuButton: async () => undefined,
+    },
+    reply: async () => ({ message_id: 2002 }),
+    answerCbQuery: async () => undefined,
+    state: {},
+  };
+
+  menuModule.ensureExecutorState(ctx);
+  const executorState = ctx.session.executor;
+  executorState.role = 'courier';
+  executorState.awaitingRoleSelection = true;
+  executorState.roleSelectionStage = 'role';
+  executorState.verification.courier.status = 'collecting';
+  executorState.verification.courier.uploadedPhotos = [
+    { fileId: 'test-file-id', messageId: 555 },
+  ];
+
+  return ctx;
+};
+
+test('executor in collecting verification resumes photo instructions on /start', async () => {
+  const originalUiStep = uiModule.ui.step;
+  const originalSetChatCommands = commandsModule.setChatCommands;
+  const originalHideClientMenu = clientMenuModule.hideClientMenu;
+  const originalShowExecutorMenu = menuModule.showExecutorMenu;
+
+  const recordedSteps = [];
+  uiModule.ui.step = async (_ctx, options) => {
+    recordedSteps.push(options);
+    return { messageId: recordedSteps.length, sent: true };
+  };
+
+  commandsModule.setChatCommands = async () => undefined;
+
+  let hideClientMenuCalls = 0;
+  clientMenuModule.hideClientMenu = async () => {
+    hideClientMenuCalls += 1;
+    return undefined;
+  };
+
+  menuModule.showExecutorMenu = async () => undefined;
+
+  const { handleStart } = require('../src/bot/commands/start');
+
+  const ctx = createTestContext();
+  const executorState = ctx.session.executor;
+
+  try {
+    await handleStart(ctx);
+  } finally {
+    uiModule.ui.step = originalUiStep;
+    commandsModule.setChatCommands = originalSetChatCommands;
+    clientMenuModule.hideClientMenu = originalHideClientMenu;
+    menuModule.showExecutorMenu = originalShowExecutorMenu;
+  }
+
+  assert.equal(executorState.role, 'courier');
+  assert.equal(executorState.awaitingRoleSelection, false);
+  assert.equal(executorState.roleSelectionStage, undefined);
+
+  const promptStep = recordedSteps.find(
+    (step) => step.id === verificationModule.VERIFICATION_PROMPT_STEP_ID,
+  );
+  assert.ok(promptStep, 'verification prompt was not shown');
+  assert.match(promptStep.text, /Фото удостоверения личности/);
+
+  assert.equal(hideClientMenuCalls, 0);
+});


### PR DESCRIPTION
## Summary
- keep the stored executor role when a derived role is available and no selection flow is active
- resume the verification card instead of forcing role reselection when photos are still being collected
- cover the regression with a unit test for executors returning to /start during photo collection

## Testing
- `node --test tests/start-executor-verification.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68da01ae6f74832d83b58074ae45dbb7