### PR TITLE
Default /from start date to now when omitted

### DIFF
--- a/src/bot/channels/commands/from.ts
+++ b/src/bot/channels/commands/from.ts
@@ -265,6 +265,10 @@ const parsePlanForm = (payload: string): ParsedPlanForm => {
     result.comment = remainder.join('\n');
   }
 
+  if (!result.startAt) {
+    result.startAt = new Date();
+  }
+
   return result;
 };
 
@@ -382,8 +386,9 @@ const handleCreateCommand = async (ctx: BotContext, command: string): Promise<vo
   if (!input) {
     await ctx.reply(
       [
-        'Не удалось разобрать данные формы. Укажите телефон, тариф (7/15/30) и дату старта.',
-        'Пример:\n/from +77001234567 @nickname 7 2024-11-20 Комментарий',
+        'Не удалось разобрать данные формы. Укажите телефон и тариф (7/15/30).',
+        'Дата старта будет проставлена автоматически, если не указана явно.',
+        'Пример:\n/from +77001234567 @nickname 7 Комментарий',
       ].join('\n'),
     );
     return;
@@ -754,4 +759,9 @@ export const registerFromCommand = (bot: Telegraf<BotContext>): void => {
       await handleEditCallback(ctx, planId);
     }
   });
+};
+
+export const __testing = {
+  parsePlanForm,
+  buildPlanInput,
 };

--- a/test/fromCommand.test.ts
+++ b/test/fromCommand.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+import type { BotContext } from '../src/bot/types';
+
+const requireFn = createRequire(__filename);
+const remindersModulePath = requireFn.resolve('../src/jobs/executorPlanReminders.ts');
+
+(requireFn.cache as Record<string, NodeModule | undefined>)[remindersModulePath] = {
+  id: remindersModulePath,
+  filename: remindersModulePath,
+  loaded: true,
+  exports: {
+    scheduleExecutorPlanReminder: async () => {},
+    cancelExecutorPlanReminders: async () => {},
+  },
+} as unknown as NodeModule;
+
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+process.env.KASPI_CARD = process.env.KASPI_CARD ?? '1234';
+process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Test User';
+process.env.KASPI_PHONE = process.env.KASPI_PHONE ?? '+70000000000';
+process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
+process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
+
+void (async () => {
+  const { __testing } = await import('../src/bot/channels/commands/from');
+
+  const payload = ['тел: +77001234567', 'план: 7', 'комм: без даты'].join('\n');
+
+  const beforeParse = Date.now();
+  const parsed = __testing.parsePlanForm(payload);
+  const afterParse = Date.now();
+
+  assert.ok(parsed.startAt, 'Дата старта должна заполняться автоматически при отсутствии ввода');
+
+  const startAtTime = parsed.startAt!.getTime();
+  assert.ok(
+    startAtTime >= beforeParse - 1_000 && startAtTime <= afterParse + 1_000,
+    'Дата старта без явного значения должна устанавливаться к текущему времени',
+  );
+
+  const fakeCtx = {
+    chat: { id: 123 },
+    message: { message_thread_id: undefined },
+  } as unknown as BotContext;
+
+  const input = __testing.buildPlanInput(fakeCtx, parsed);
+  assert.ok(input, 'План должен создаваться при передаче телефона, тарифа и стартовой даты по умолчанию');
+  assert.equal(
+    input!.startAt.getTime(),
+    startAtTime,
+    'Созданный план должен использовать автоматически выбранную дату старта',
+  );
+
+  console.log('from command default start date test: OK');
+})();


### PR DESCRIPTION
## Summary
- default the parsed /from start date to the current time when no date is provided
- update the moderator validation hint to reflect the automatic date handling
- add a regression test covering /from submissions without an explicit date

## Testing
- TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register test/fromCommand.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da63fe1fd4832d99de0181696c1044