### PR TITLE
Add executor plan end date tracking

### DIFF
--- a/db/migrations/0016_executor_plans.up.sql
+++ b/db/migrations/0016_executor_plans.up.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS executor_plans (
   nickname TEXT,
   plan_choice TEXT NOT NULL CHECK (plan_choice IN ('7','15','30')),
   start_at TIMESTAMPTZ NOT NULL,
+  ends_at TIMESTAMPTZ NOT NULL,
   comment TEXT,
   status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','blocked','completed','cancelled')),
   muted BOOLEAN NOT NULL DEFAULT FALSE,
@@ -31,3 +32,6 @@ CREATE INDEX IF NOT EXISTS executor_plans_status_idx
 
 CREATE INDEX IF NOT EXISTS executor_plans_start_idx
   ON executor_plans (start_at);
+
+CREATE INDEX IF NOT EXISTS executor_plans_ends_idx
+  ON executor_plans (ends_at);

--- a/db/migrations/0017_executor_plan_ends_at.down.sql
+++ b/db/migrations/0017_executor_plan_ends_at.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS executor_plans_ends_idx;
+
+ALTER TABLE executor_plans
+  DROP COLUMN IF EXISTS ends_at;

--- a/db/migrations/0017_executor_plan_ends_at.up.sql
+++ b/db/migrations/0017_executor_plan_ends_at.up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE executor_plans
+  ADD COLUMN IF NOT EXISTS ends_at TIMESTAMPTZ;
+
+UPDATE executor_plans
+SET ends_at = start_at
+  + CASE plan_choice
+      WHEN '7' THEN INTERVAL '7 days'
+      WHEN '15' THEN INTERVAL '15 days'
+      WHEN '30' THEN INTERVAL '30 days'
+      ELSE INTERVAL '0 days'
+    END
+WHERE ends_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS executor_plans_ends_idx
+  ON executor_plans (ends_at);
+
+ALTER TABLE executor_plans
+  ALTER COLUMN ends_at SET NOT NULL;

--- a/src/jobs/executorPlanReminders.ts
+++ b/src/jobs/executorPlanReminders.ts
@@ -50,7 +50,7 @@ const computeReminderTime = (
     return null;
   }
 
-  const target = new Date(plan.startAt.getTime() + offset * 60 * 60 * 1000);
+  const target = new Date(plan.endsAt.getTime() + offset * 60 * 60 * 1000);
   return target;
 };
 
@@ -231,7 +231,7 @@ const ensureQueue = (): boolean => {
   });
   worker = new Worker<ReminderJobData>(
     QUEUE_NAME,
-    async (job) => {
+    async (job: { data: ReminderJobData; id?: string | number | null }) => {
       try {
         await handleReminderJob(job.data);
       } catch (error) {
@@ -245,7 +245,7 @@ const ensureQueue = (): boolean => {
     },
   );
 
-  worker.on('error', (error) => {
+  worker.on('error', (error: unknown) => {
     logger.error({ err: error }, 'Executor plan reminder worker error');
   });
 
@@ -268,6 +268,10 @@ const initialisePlanSchedules = async (): Promise<void> => {
   for (const plan of plans) {
     await scheduleReminder(plan);
   }
+};
+
+export const __testing = {
+  computeReminderTime,
 };
 
 export const startExecutorPlanReminderService = (

--- a/src/services/executorPlans/reminders.ts
+++ b/src/services/executorPlans/reminders.ts
@@ -18,12 +18,6 @@ const formatDateTime = (value: Date): string =>
     timeZone: config.timezone,
   }).format(value);
 
-const formatDate = (value: Date): string =>
-  new Intl.DateTimeFormat('ru-RU', {
-    dateStyle: 'medium',
-    timeZone: config.timezone,
-  }).format(value);
-
 export const formatPlanChoice = (plan: ExecutorPlanRecord): string => {
   switch (plan.planChoice) {
     case '7':
@@ -61,6 +55,7 @@ export const buildPlanSummary = (plan: ExecutorPlanRecord): string => {
   }
   lines.push(`Тариф: ${formatPlanChoice(plan)}`);
   lines.push(`Старт: ${formatDateTime(plan.startAt)}`);
+  lines.push(`Окончание: ${formatDateTime(plan.endsAt)}`);
   lines.push(`Статус: ${formatPlanStatus(plan)}${plan.muted ? ' (уведомления отключены)' : ''}`);
   lines.push(`Текущий этап напоминаний: ${REMINDER_STAGE_LABELS[plan.reminderIndex] ?? 'завершён'}`);
   if (plan.comment) {
@@ -81,7 +76,8 @@ export const buildReminderMessage = (
     lines.push(`Ник/ID: ${plan.nickname}`);
   }
   lines.push(`План: ${formatPlanChoice(plan)}`);
-  lines.push(`Старт: ${formatDate(plan.startAt)}`);
+  lines.push(`Старт: ${formatDateTime(plan.startAt)}`);
+  lines.push(`Окончание: ${formatDateTime(plan.endsAt)}`);
   if (plan.comment) {
     lines.push('', `Комментарий: ${plan.comment}`);
   }

--- a/src/types/bullmq.ts
+++ b/src/types/bullmq.ts
@@ -1,0 +1,21 @@
+declare module 'bullmq' {
+  export interface JobsOptions {
+    jobId?: string;
+    delay?: number;
+    removeOnComplete?: boolean | number;
+    removeOnFail?: boolean | number;
+  }
+
+  export class Queue<T = unknown> {
+    constructor(name: string, options?: unknown);
+    add(name: string, data: T, options?: JobsOptions): Promise<void>;
+    remove(jobId: string): Promise<void>;
+    close(): Promise<void>;
+  }
+
+  export class Worker<T = unknown> {
+    constructor(name: string, processor: (...args: any[]) => unknown, options?: unknown);
+    on(event: string, handler: (...args: any[]) => void): void;
+    close(): Promise<void>;
+  }
+}

--- a/src/types/executorPlans.ts
+++ b/src/types/executorPlans.ts
@@ -10,6 +10,7 @@ export interface ExecutorPlanRecord {
   nickname?: string;
   planChoice: ExecutorPlanChoice;
   startAt: Date;
+  endsAt: Date;
   comment?: string;
   status: ExecutorPlanStatus;
   muted: boolean;
@@ -26,5 +27,6 @@ export interface ExecutorPlanInsertInput {
   nickname?: string;
   planChoice: ExecutorPlanChoice;
   startAt: Date;
+  endsAt?: Date;
   comment?: string;
 }

--- a/test/executorPlanReminders.test.ts
+++ b/test/executorPlanReminders.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+import { createRequire } from 'node:module';
+
+import '../src/types/bullmq';
+
+import type { ExecutorPlanRecord } from '../src/types';
+
+const requireFn = createRequire(__filename);
+
+const moduleConstructor = Module as unknown as {
+  _resolveFilename: (
+    request: string,
+    parent?: NodeModule | null,
+    isMain?: boolean,
+    options?: unknown,
+  ) => string;
+};
+
+const originalResolveFilename = moduleConstructor._resolveFilename;
+moduleConstructor._resolveFilename = function patchedResolveFilename(
+  request: string,
+  parent?: NodeModule | null,
+  isMain?: boolean,
+  options?: unknown,
+): string {
+  if (request === 'bullmq') {
+    return request;
+  }
+
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+(requireFn.cache as Record<string, NodeModule | undefined>).bullmq = {
+  id: 'bullmq',
+  filename: 'bullmq',
+  loaded: true,
+  exports: {
+    Queue: class {},
+    Worker: class {},
+  },
+} as unknown as NodeModule;
+
+process.env.NODE_ENV = process.env.NODE_ENV ?? 'test';
+process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+process.env.KASPI_CARD = process.env.KASPI_CARD ?? '1234';
+process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Test User';
+process.env.KASPI_PHONE = process.env.KASPI_PHONE ?? '+70000000000';
+process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
+process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
+
+void (async () => {
+  const { REMINDER_OFFSETS_HOURS } = await import('../src/services/executorPlans/reminders');
+  const { __testing } = await import('../src/jobs/executorPlanReminders');
+
+  const { computeReminderTime } = __testing;
+
+  const PLAN_CONFIGS: Array<{ choice: ExecutorPlanRecord['planChoice']; days: number }> = [
+    { choice: '7', days: 7 },
+    { choice: '15', days: 15 },
+    { choice: '30', days: 30 },
+  ];
+
+  const msPerHour = 60 * 60 * 1000;
+  const msPerDay = 24 * msPerHour;
+  const base = new Date('2024-01-01T00:00:00Z');
+
+  for (const { choice, days } of PLAN_CONFIGS) {
+    const endsAt = new Date(base.getTime() + days * msPerDay);
+    const plan: ExecutorPlanRecord = {
+      id: 1,
+      chatId: 1,
+      threadId: undefined,
+      phone: '+70000000000',
+      nickname: undefined,
+      planChoice: choice,
+      startAt: base,
+      endsAt,
+      comment: undefined,
+      status: 'active',
+      muted: false,
+      reminderIndex: 0,
+      reminderLastSent: undefined,
+      createdAt: base,
+      updatedAt: base,
+    };
+
+    for (let index = 0; index < REMINDER_OFFSETS_HOURS.length; index += 1) {
+      const expected = new Date(endsAt.getTime() + REMINDER_OFFSETS_HOURS[index] * msPerHour);
+      const actual = computeReminderTime(plan, index);
+      assert.ok(actual, `Напоминание ${index} должно вычисляться для плана ${choice}`);
+      assert.equal(
+        actual.getTime(),
+        expected.getTime(),
+        `Неверное время напоминания ${index} для плана на ${days} дней`,
+      );
+    }
+
+    const outOfRange = computeReminderTime(plan, REMINDER_OFFSETS_HOURS.length);
+    assert.equal(outOfRange, null, 'Напоминание вне диапазона должно возвращать null');
+  }
+
+  console.log('executor plan reminder timing tests: OK');
+})();


### PR DESCRIPTION
## Summary
- add an ends_at column and index to executor_plans with a migration that backfills existing rows
- compute executor plan end dates in the DB layer and expose them throughout the reminder summaries and scheduling logic
- extend reminder scheduling tests to cover 7/15/30-day plans anchored to endsAt

## Testing
- npx ts-node test/fromCommand.test.ts
- npx ts-node test/executorPlanReminders.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da70392458832d803f6b33d873a723