### PR TITLE
Add Redis-backed phone capture retries and sync worker

### DIFF
--- a/src/bot/services/executorAccess.ts
+++ b/src/bot/services/executorAccess.ts
@@ -55,6 +55,7 @@ const loadExecutorAccessFromCache = async (
 const saveExecutorAccessToCache = async (
   executorId: number,
   record: ExecutorOrderAccessRecord,
+  ttlSeconds = CACHE_TTL_SECONDS,
 ): Promise<void> => {
   const client = getRedisClient();
   if (!client) {
@@ -64,7 +65,7 @@ const saveExecutorAccessToCache = async (
   const cacheKey = formatCacheKey(executorId);
 
   try {
-    await client.set(cacheKey, JSON.stringify(record), 'EX', CACHE_TTL_SECONDS);
+    await client.set(cacheKey, JSON.stringify(record), 'EX', ttlSeconds);
   } catch (error) {
     logger.warn({ err: error, executorId }, 'Failed to save executor access cache');
   }
@@ -115,6 +116,14 @@ export const getExecutorOrderAccess = async (
   }
 
   return record;
+};
+
+export const primeExecutorOrderAccessCache = async (
+  executorId: number,
+  record: ExecutorOrderAccessRecord,
+  options?: { ttlSeconds?: number },
+): Promise<void> => {
+  await saveExecutorAccessToCache(executorId, record, options?.ttlSeconds);
 };
 
 export const hasExecutorOrderAccess = async (executorId: number): Promise<boolean> => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -316,6 +316,7 @@ export interface AppConfig {
     subscription: string;
     metrics: string;
     paymentReminder: string;
+    phoneSyncIntervalMs: number;
   };
   tariff: TariffRates | null;
   subscriptions: {
@@ -398,6 +399,7 @@ export const loadConfig = (): AppConfig => {
       subscription: getCronExpression('JOBS_SUBSCRIPTION_CRON', '*/10 * * * *'),
       metrics: getCronExpression('JOBS_METRICS_CRON', '*/60 * * * * *'),
       paymentReminder: getCronExpression('JOBS_PAYMENT_REMINDER_CRON', '*/10 * * * *'),
+      phoneSyncIntervalMs: parsePositiveInt('JOBS_PHONE_SYNC_INTERVAL_MS', 5000),
     },
     tariff: parseGeneralTariff(),
     subscriptions: {

--- a/src/db/phoneVerification.ts
+++ b/src/db/phoneVerification.ts
@@ -1,0 +1,29 @@
+import { pool } from './client';
+
+export interface PhoneVerificationUpdate {
+  telegramId: number;
+  phone: string;
+}
+
+export const persistPhoneVerification = async ({
+  telegramId,
+  phone,
+}: PhoneVerificationUpdate): Promise<void> => {
+  await pool.query(
+    `
+      UPDATE users
+      SET
+        phone = $1,
+        phone_verified = true,
+        status = CASE
+          WHEN status IN ('suspended', 'banned') THEN status
+          WHEN status IN ('awaiting_phone', 'guest') THEN 'onboarding'
+          WHEN status IS NULL THEN 'onboarding'
+          ELSE status
+        END,
+        updated_at = now()
+      WHERE tg_id = $2
+    `,
+    [phone, telegramId],
+  );
+};

--- a/src/infra/userPhoneQueue.ts
+++ b/src/infra/userPhoneQueue.ts
@@ -1,0 +1,78 @@
+import { config, logger } from '../config';
+import { persistPhoneVerification } from '../db/phoneVerification';
+import { getRedisClient } from './redis';
+
+const PHONE_UPDATE_QUEUE_KEY = 'user-phone-updates';
+const MAX_UPDATES_PER_FLUSH = 100;
+
+export interface QueuedPhoneUpdate {
+  telegramId: number;
+  phone: string;
+}
+
+const resolveQueueKey = (): string => {
+  const prefix = config.session.redis?.keyPrefix ?? 'session:';
+  return `${prefix}${PHONE_UPDATE_QUEUE_KEY}`;
+};
+
+const serialiseUpdate = (update: QueuedPhoneUpdate): string => JSON.stringify(update);
+
+const parseUpdate = (raw: string): QueuedPhoneUpdate | null => {
+  try {
+    const parsed = JSON.parse(raw) as Partial<QueuedPhoneUpdate>;
+    if (
+      !parsed
+      || typeof parsed.telegramId !== 'number'
+      || Number.isNaN(parsed.telegramId)
+      || typeof parsed.phone !== 'string'
+    ) {
+      return null;
+    }
+
+    return { telegramId: parsed.telegramId, phone: parsed.phone };
+  } catch (error) {
+    logger.error({ err: error, raw }, 'Failed to parse queued phone update payload');
+    return null;
+  }
+};
+
+export const enqueueUserPhoneUpdate = async (update: QueuedPhoneUpdate): Promise<void> => {
+  const redis = getRedisClient();
+  if (!redis) {
+    throw new Error('Redis is not configured; cannot enqueue phone update');
+  }
+
+  await redis.rpush(resolveQueueKey(), serialiseUpdate(update));
+};
+
+export const flushUserPhoneUpdates = async (): Promise<void> => {
+  const redis = getRedisClient();
+  if (!redis) {
+    return;
+  }
+
+  const queueKey = resolveQueueKey();
+
+  for (let processed = 0; processed < MAX_UPDATES_PER_FLUSH; processed += 1) {
+    const raw = await redis.lpop(queueKey);
+    if (!raw) {
+      break;
+    }
+
+    const update = parseUpdate(raw);
+    if (!update) {
+      continue;
+    }
+
+    try {
+      await persistPhoneVerification(update);
+    } catch (error) {
+      logger.error(
+        { err: error, telegramId: update.telegramId },
+        'Failed to persist queued phone update',
+      );
+      await redis.lpush(queueKey, raw);
+      break;
+    }
+  }
+};

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -8,6 +8,7 @@ import {
   startExecutorPlanReminderService,
   stopExecutorPlanReminderService,
 } from './executorPlanReminders';
+import { startUserPhoneSync, stopUserPhoneSync } from './userPhoneSync';
 
 let initialized = false;
 
@@ -20,6 +21,7 @@ export const registerJobs = (bot: Telegraf<BotContext>): void => {
   startInactivityNudger(bot);
   startMetricsReporter();
   startExecutorPlanReminderService(bot);
+  startUserPhoneSync();
   initialized = true;
 };
 
@@ -32,5 +34,6 @@ export const stopJobs = (): void => {
   stopSubscriptionScheduler();
   stopMetricsReporter();
   void stopExecutorPlanReminderService();
+  stopUserPhoneSync();
   initialized = false;
 };

--- a/src/jobs/userPhoneSync.ts
+++ b/src/jobs/userPhoneSync.ts
@@ -1,0 +1,35 @@
+import { config, logger } from '../config';
+import { flushUserPhoneUpdates } from '../infra/userPhoneQueue';
+
+let timer: NodeJS.Timeout | null = null;
+
+const runFlush = async (): Promise<void> => {
+  try {
+    await flushUserPhoneUpdates();
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to flush queued phone updates');
+  }
+};
+
+export const startUserPhoneSync = (): void => {
+  if (timer) {
+    return;
+  }
+
+  void runFlush();
+
+  timer = setInterval(() => {
+    void runFlush();
+  }, config.jobs.phoneSyncIntervalMs);
+
+  timer.unref?.();
+};
+
+export const stopUserPhoneSync = (): void => {
+  if (!timer) {
+    return;
+  }
+
+  clearInterval(timer);
+  timer = null;
+};

--- a/tests/phone-collect.test.js
+++ b/tests/phone-collect.test.js
@@ -1,0 +1,232 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+const ensureEnv = (key, value) => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+enableTestEnv();
+
+function enableTestEnv() {
+  ensureEnv('BOT_TOKEN', 'test-bot-token');
+  ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+  ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+  ensureEnv('KASPI_NAME', 'Test User');
+  ensureEnv('KASPI_PHONE', '+70000000000');
+  ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+  ensureEnv('WEBHOOK_SECRET', 'secret');
+}
+
+const createMockRedis = () => {
+  const strings = new Map();
+  const lists = new Map();
+  const setCalls = [];
+
+  const getList = (key) => lists.get(key) ?? [];
+
+  const ensureList = (key) => {
+    if (!lists.has(key)) {
+      lists.set(key, []);
+    }
+    return lists.get(key);
+  };
+
+  return {
+    setCalls,
+    getList,
+    async get(key) {
+      return strings.has(key) ? strings.get(key) : null;
+    },
+    async set(key, value, mode, ttl) {
+      if (mode && mode !== 'EX') {
+        throw new Error(`Unsupported set mode: ${mode}`);
+      }
+      if (mode === 'EX' && typeof ttl !== 'number') {
+        throw new Error('TTL must be provided when using EX');
+      }
+      strings.set(key, value);
+      setCalls.push({ key, value, mode, ttl });
+    },
+    async rpush(key, value) {
+      const list = ensureList(key);
+      list.push(value);
+      return list.length;
+    },
+    async lpush(key, value) {
+      const list = ensureList(key);
+      list.unshift(value);
+      return list.length;
+    },
+    async lpop(key) {
+      const list = ensureList(key);
+      if (list.length === 0) {
+        return null;
+      }
+      const value = list.shift();
+      return value ?? null;
+    },
+  };
+};
+
+const loadPhoneCollect = () => {
+  delete require.cache[require.resolve('../src/bot/flows/common/phoneCollect')];
+  return require('../src/bot/flows/common/phoneCollect');
+};
+
+const queueModule = require('../src/infra/userPhoneQueue');
+const redisModule = require('../src/infra/redis');
+const phoneVerificationModule = require('../src/db/phoneVerification');
+const executorAccessModule = require('../src/bot/services/executorAccess');
+const reportsModule = require('../src/bot/services/reports');
+const config = require('../src/config').config;
+
+const queueKey = `${config.session.redis?.keyPrefix ?? 'session:'}user-phone-updates`;
+
+test('savePhone persists contact immediately when database is available', { concurrency: 1 }, async (t) => {
+  const mockRedis = createMockRedis();
+  const originalGetRedisClient = redisModule.getRedisClient;
+  redisModule.getRedisClient = () => mockRedis;
+
+  const calls = [];
+  const originalPersist = phoneVerificationModule.persistPhoneVerification;
+  phoneVerificationModule.persistPhoneVerification = async (payload) => {
+    calls.push(payload);
+  };
+
+  const cacheCalls = [];
+  const originalPrime = executorAccessModule.primeExecutorOrderAccessCache;
+  executorAccessModule.primeExecutorOrderAccessCache = async (executorId, record, options) => {
+    cacheCalls.push({ executorId, record, options });
+    await originalPrime(executorId, record, options);
+  };
+
+  let registrations = 0;
+  let verifications = 0;
+  const originalReportRegistration = reportsModule.reportUserRegistration;
+  const originalReportPhone = reportsModule.reportPhoneVerified;
+  reportsModule.reportUserRegistration = async () => {
+    registrations += 1;
+  };
+  reportsModule.reportPhoneVerified = async () => {
+    verifications += 1;
+  };
+
+  const { savePhone } = loadPhoneCollect();
+
+  const ctx = {
+    chat: { type: 'private' },
+    from: { id: 123 },
+    message: { contact: { phone_number: '8 (701) 000-00-00', user_id: 123 } },
+    session: { awaitingPhone: true, ephemeralMessages: [], user: { id: 123, phoneVerified: false } },
+    auth: { user: { telegramId: 123, phoneVerified: false, status: 'awaiting_phone', isBlocked: false } },
+    state: {},
+  };
+
+  try {
+    await savePhone(ctx, async () => {});
+
+    assert.equal(calls.length, 1, 'should persist phone once');
+    assert.deepEqual(calls[0], { telegramId: 123, phone: '+87010000000' });
+    assert.equal(ctx.session.awaitingPhone, false);
+    assert.equal(ctx.session.phoneNumber, '+87010000000');
+    assert.equal(ctx.session.user.phoneVerified, true);
+    assert.equal(ctx.auth.user.phone, '+87010000000');
+    assert.equal(ctx.auth.user.phoneVerified, true);
+    assert.equal(ctx.auth.user.status, 'onboarding');
+    assert.equal(ctx.state.phoneJustVerified, true);
+    assert.equal(registrations, 1);
+    assert.equal(verifications, 1);
+    assert.equal(mockRedis.getList(queueKey).length, 0, 'queue should stay empty');
+    assert.equal(cacheCalls.length, 1, 'cache primed once');
+    assert.equal(cacheCalls[0].executorId, 123);
+    assert.deepEqual(cacheCalls[0].record, { hasPhone: true, isBlocked: false });
+    assert.equal(cacheCalls[0].options.ttlSeconds, 3600);
+    assert.equal(mockRedis.setCalls.length, 1, 'cache write recorded');
+    assert.equal(mockRedis.setCalls[0].ttl, 3600);
+  } finally {
+    redisModule.getRedisClient = originalGetRedisClient;
+    phoneVerificationModule.persistPhoneVerification = originalPersist;
+    executorAccessModule.primeExecutorOrderAccessCache = originalPrime;
+    reportsModule.reportUserRegistration = originalReportRegistration;
+    reportsModule.reportPhoneVerified = originalReportPhone;
+  }
+});
+
+test('savePhone enqueues update when database is unavailable and flush later succeeds', { concurrency: 1 }, async (t) => {
+  const mockRedis = createMockRedis();
+  const originalGetRedisClient = redisModule.getRedisClient;
+  redisModule.getRedisClient = () => mockRedis;
+
+  let shouldFail = true;
+  const calls = [];
+  const originalPersist = phoneVerificationModule.persistPhoneVerification;
+  phoneVerificationModule.persistPhoneVerification = async (payload) => {
+    calls.push(payload);
+    if (shouldFail) {
+      throw new Error('temporary failure');
+    }
+  };
+
+  const cacheCalls = [];
+  const originalPrime = executorAccessModule.primeExecutorOrderAccessCache;
+  executorAccessModule.primeExecutorOrderAccessCache = async (executorId, record, options) => {
+    cacheCalls.push({ executorId, record, options });
+    await originalPrime(executorId, record, options);
+  };
+
+  let registrations = 0;
+  let verifications = 0;
+  const originalReportRegistration = reportsModule.reportUserRegistration;
+  const originalReportPhone = reportsModule.reportPhoneVerified;
+  reportsModule.reportUserRegistration = async () => {
+    registrations += 1;
+  };
+  reportsModule.reportPhoneVerified = async () => {
+    verifications += 1;
+  };
+
+  const { savePhone } = loadPhoneCollect();
+
+  const ctx = {
+    chat: { type: 'private' },
+    from: { id: 456 },
+    message: { contact: { phone_number: '+7 701 111-22-33', user_id: 456 } },
+    session: { awaitingPhone: true, ephemeralMessages: [], user: { id: 456, phoneVerified: false } },
+    auth: { user: { telegramId: 456, phoneVerified: false, status: 'guest', isBlocked: true } },
+    state: {},
+  };
+
+  try {
+    await savePhone(ctx, async () => {});
+
+    assert.equal(calls.length, 1, 'initial persistence attempted once');
+    assert.equal(mockRedis.getList(queueKey).length, 1, 'queued update should be stored');
+    assert.equal(ctx.session.awaitingPhone, false);
+    assert.equal(ctx.session.phoneNumber, '+7 701 111-22-33');
+    assert.equal(ctx.session.user.phoneVerified, true);
+    assert.equal(ctx.auth.user.phone, '+7 701 111-22-33');
+    assert.equal(ctx.auth.user.phoneVerified, true);
+    assert.equal(ctx.auth.user.status, 'onboarding');
+    assert.equal(ctx.state.phoneJustVerified, true);
+    assert.equal(registrations, 1);
+    assert.equal(verifications, 1);
+    assert.equal(cacheCalls.length, 1);
+    assert.deepEqual(cacheCalls[0].record, { hasPhone: true, isBlocked: true });
+
+    shouldFail = false;
+    await queueModule.flushUserPhoneUpdates();
+
+    assert.equal(calls.length, 2, 'queued update retried once');
+    assert.equal(mockRedis.getList(queueKey).length, 0, 'queue should be empty after flush');
+  } finally {
+    redisModule.getRedisClient = originalGetRedisClient;
+    phoneVerificationModule.persistPhoneVerification = originalPersist;
+    executorAccessModule.primeExecutorOrderAccessCache = originalPrime;
+    reportsModule.reportUserRegistration = originalReportRegistration;
+    reportsModule.reportPhoneVerified = originalReportPhone;
+  }
+});


### PR DESCRIPTION
## Summary
- queue verified phone updates in Redis when the direct `UPDATE users` fails while still updating in-memory auth and session state
- add a Redis-backed background worker to flush queued phone updates once Postgres is reachable and prime executor access cache on capture
- cover both immediate persistence and deferred retry paths with new phone-collect tests

## Testing
- `node --test tests/phone-collect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68da703c42e8832db0da978c1b172eb6