### PR TITLE
Fix executor jobs registration export definition

### DIFF
--- a/src/bot/flows/executor/jobs.ts
+++ b/src/bot/flows/executor/jobs.ts
@@ -601,10 +601,4 @@ export const registerExecutorJobs = (bot: Telegraf<BotContext>): void => {
 
     await handleCompletionAction(ctx, orderId);
   });
-
-export const registerExecutorJobs = (_bot: Telegraf<BotContext>): void => {
-  // Интерактивная лента заказов отключена.
-
 };
-
-export const registerExecutorOrders = registerExecutorJobs;


### PR DESCRIPTION
## Summary
- close the registerExecutorJobs handler registration block
- remove the duplicate empty registerExecutorJobs stub export

## Testing
- npm run build *(fails: existing TypeScript errors in several files)*

------
https://chatgpt.com/codex/tasks/task_e_68da788ee0dc832d8b92b34f2636cb04