### PR TITLE
Fix keyboard guard priority for client support

### DIFF
--- a/src/bot/middlewares/keyboardGuard.ts
+++ b/src/bot/middlewares/keyboardGuard.ts
@@ -71,14 +71,26 @@ export const keyboardGuard = (): MiddlewareFn<BotContext> => async (ctx, next) =
   }
 
   const executor = isExecutorUser(ctx);
+  const inClientMenu = CLIENT_WHITELIST.has(text);
+  const inExecutorMenu = EXECUTOR_WHITELIST.has(text);
 
-  if (EXECUTOR_WHITELIST.has(text) && !executor) {
-    await ctx.reply('Этот раздел доступен только исполнителям.', clientKeyboard());
+  if (inClientMenu) {
+    if (executor) {
+      await ctx.reply('Вы сейчас в режиме исполнителя. Используйте меню исполнителя ниже.', executorKeyboard());
+      return;
+    }
+
+    await next();
     return;
   }
 
-  if (CLIENT_WHITELIST.has(text) && executor) {
-    await ctx.reply('Вы сейчас в режиме исполнителя. Используйте меню исполнителя ниже.', executorKeyboard());
+  if (inExecutorMenu) {
+    if (!executor) {
+      await ctx.reply('Этот раздел доступен только исполнителям.', clientKeyboard());
+      return;
+    }
+
+    await next();
     return;
   }
 

--- a/tests/keyboard-guard.test.js
+++ b/tests/keyboard-guard.test.js
@@ -1,0 +1,90 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+const ensureEnv = (key, value) => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+ensureEnv('BOT_TOKEN', 'test-bot-token');
+ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+ensureEnv('KASPI_NAME', 'Test User');
+ensureEnv('KASPI_PHONE', '+70000000000');
+ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+ensureEnv('WEBHOOK_SECRET', 'secret');
+
+const { CLIENT_MENU } = require('../src/ui/clientMenu');
+const { keyboardGuard } = require('../src/bot/middlewares/keyboardGuard');
+const { promptClientSupport } = require('../src/bot/flows/client/support');
+
+test('keyboardGuard allows clients to reach support prompt', async () => {
+
+  const replies = [];
+
+  const ctx = {
+    chat: { id: 42, type: 'private' },
+    message: { text: CLIENT_MENU.support },
+    auth: {
+      user: {
+        role: 'client',
+        status: 'active_client',
+        phoneVerified: true,
+      },
+    },
+    session: {},
+    reply: async (text) => {
+      replies.push(text);
+    },
+  };
+
+  const guard = keyboardGuard();
+  let nextCalled = false;
+
+  await guard(ctx, async () => {
+    nextCalled = true;
+    await promptClientSupport(ctx);
+  });
+
+  assert.equal(nextCalled, true, 'Client support text should reach the next middleware');
+  assert.equal(replies.length, 1, 'Client should receive the support prompt reply');
+  assert.match(replies[0], /^🆘 Связаться с поддержкой\./, 'Support prompt should be shown');
+});
+
+test('keyboardGuard blocks executors from client support menu', async () => {
+  const replies = [];
+
+  const ctx = {
+    chat: { id: 43, type: 'private' },
+    message: { text: CLIENT_MENU.support },
+    auth: {
+      user: {
+        role: 'executor',
+        status: 'active_executor',
+        phoneVerified: true,
+      },
+    },
+    session: {},
+    reply: async (text) => {
+      replies.push(text);
+    },
+  };
+
+  const guard = keyboardGuard();
+  let nextCalled = false;
+
+  await guard(ctx, async () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false, 'Executor should not reach support handler');
+  assert.equal(replies.length, 1, 'Executor should receive a warning message');
+  assert.equal(
+    replies[0],
+    'Вы сейчас в режиме исполнителя. Используйте меню исполнителя ниже.',
+    'Executor should be prompted to use the executor menu',
+  );
+});


### PR DESCRIPTION
## Summary
- ensure keyboard guard prefers client actions when labels overlap so shared buttons reach the proper handler
- keep executor-only access controls intact while allowing client support requests through
- add integration tests covering client support access and executor warnings for overlapping labels

## Testing
- node --test tests/keyboard-guard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dae4b7c6b4832d8ceb7b339f85dc2f