### PR TITLE
Hide subscription UI for clients

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -14,7 +14,7 @@ import { CLIENT_COMMANDS } from '../../commands/sets';
 import { setChatCommands } from '../../services/commands';
 import type { BotContext } from '../../types';
 import { presentRolePick } from '../../commands/start';
-import { ensureExecutorState, EXECUTOR_SUBSCRIPTION_ACTION } from '../executor/menu';
+import { ensureExecutorState } from '../executor/menu';
 import { reportRoleSet, toUserIdentity } from '../../services/reports';
 import { promptClientSupport } from './support';
 import { askCity, getCityFromContext, CITY_ACTION_PATTERN } from '../common/citySelect';
@@ -45,7 +45,6 @@ const buildClientProfileOptions = () => ({
   backAction: CLIENT_MENU_ACTION,
   homeAction: CLIENT_MENU_ACTION,
   changeCityAction: CLIENT_MENU_CITY_SELECT_ACTION,
-  subscriptionAction: EXECUTOR_SUBSCRIPTION_ACTION,
   supportAction: CLIENT_MENU_SUPPORT_ACTION,
 });
 export const logClientMenuClick = async (

--- a/src/bot/flows/common/profileCard.ts
+++ b/src/bot/flows/common/profileCard.ts
@@ -111,6 +111,9 @@ const formatTrialStatus = (user: AuthUser): string => {
   return deadline ? `активен до ${deadline}` : 'активен';
 };
 
+const shouldHideSubscriptionForUser = (ctx: BotContext): boolean =>
+  ctx.auth?.user.role === 'client';
+
 const PERFORMANCE_LABELS: Record<string, string> = {
   completionRate: 'Доля завершённых заказов',
   ordersCompleted: 'Выполнено заказов',
@@ -198,7 +201,9 @@ export const buildProfileCardText = (ctx: BotContext): string => {
 
   lines.push('');
   lines.push(`Верификация: ${formatVerificationStatus(authUser)}`);
-  lines.push(`Подписка: ${formatSubscriptionStatus(authUser)}`);
+  if (!shouldHideSubscriptionForUser(ctx)) {
+    lines.push(`Подписка: ${formatSubscriptionStatus(authUser)}`);
+  }
   lines.push(`Пробный период: ${formatTrialStatus(authUser)}`);
   lines.push(`Активный заказ: ${authUser.hasActiveOrder ? 'да' : 'нет'}`);
 
@@ -224,7 +229,7 @@ const buildProfileCardKeyboard = (
     rows.push([{ label: '🏙️ Сменить город', action: options.changeCityAction }]);
   }
 
-  if (options.subscriptionAction) {
+  if (options.subscriptionAction && !shouldHideSubscriptionForUser(ctx)) {
     rows.push([{ label: '💳 Подписка', action: options.subscriptionAction }]);
   }
 

--- a/tests/profile-card.test.js
+++ b/tests/profile-card.test.js
@@ -79,7 +79,7 @@ test('buildProfileCardText enriches client profile with statuses and metrics', (
   const text = buildProfileCardText(ctx);
 
   assert.match(text, /Верификация: на проверке/);
-  assert.match(text, /Подписка: пробный доступ/);
+  assert.doesNotMatch(text, /Подписка:/);
   assert.match(text, /Пробный период: активен до/);
   assert.match(text, /Активный заказ: нет/);
   assert.match(text, /Показатели:/);
@@ -97,10 +97,15 @@ test('buildProfileCardText enriches client profile with statuses and metrics', (
   const labels = keyboard.inline_keyboard.map((row) => row.map((button) => button.text));
   assert.deepEqual(labels, [
     ['🏙️ Сменить город'],
-    ['💳 Подписка'],
     ['🆘 Помощь'],
     ['⬅ Назад', '🏠 Главное меню'],
   ]);
+
+  for (const row of labels) {
+    for (const label of row) {
+      assert.notEqual(label, '💳 Подписка');
+    }
+  }
 
   const cityButton = keyboard.inline_keyboard[0][0];
   const cityDecoded = tryDecodeCallbackData(cityButton.callback_data);
@@ -108,7 +113,12 @@ test('buildProfileCardText enriches client profile with statuses and metrics', (
   assert.equal(cityDecoded.wrapped.raw, 'client:menu:city');
   assert.ok(cityDecoded.wrapped.nonce);
 
-  const supportButtonClient = keyboard.inline_keyboard[2][0];
+  const supportRowClient = keyboard.inline_keyboard.find((row) =>
+    row.some((button) => button.text === '🆘 Помощь'),
+  );
+  assert.ok(supportRowClient);
+  const supportButtonClient = supportRowClient.find((button) => button.text === '🆘 Помощь');
+  assert.ok(supportButtonClient);
   const supportDecodedClient = tryDecodeCallbackData(supportButtonClient.callback_data);
   assert.equal(supportDecodedClient.ok, true);
   assert.equal(supportDecodedClient.wrapped.raw, 'client:menu:support');


### PR DESCRIPTION
## Summary
- stop passing the subscription action to the client profile card options so the menu no longer links to it
- hide the subscription line and button when rendering a profile card for client users while keeping it for executors
- update profile card tests to cover the differing subscription visibility for clients versus executors

## Testing
- node --test tests/profile-card.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dae7b98918832d98204256434e74c8