### PR TITLE
Allow trial-expired clients through state gate

### DIFF
--- a/src/bot/middlewares/stateGate.ts
+++ b/src/bot/middlewares/stateGate.ts
@@ -26,6 +26,17 @@ const getMessageText = (ctx: BotContext): string | undefined => {
   return trimmed.length > 0 ? trimmed : undefined;
 };
 
+const isExecutorUser = (ctx: BotContext): boolean => {
+  const role = ctx.auth?.user?.role;
+  const status = ctx.auth?.user?.status;
+
+  if (!ctx.auth?.user) {
+    return false;
+  }
+
+  return role === 'executor' || role === 'moderator' || status === 'active_executor';
+};
+
 export const stateGate = (): MiddlewareFn<BotContext> => async (ctx, next) => {
   const chatType = ctx.chat?.type;
   const isChannelChat = chatType === 'channel';
@@ -86,7 +97,9 @@ export const stateGate = (): MiddlewareFn<BotContext> => async (ctx, next) => {
     return;
   }
 
-  if (user.status === 'trial_expired') {
+  const executor = isExecutorUser(ctx);
+
+  if (executor && user.status === 'trial_expired') {
     const warning =
       'Пробный период завершён. Продлите подписку, чтобы продолжить получать заказы.';
     await answerCallbackQuery(warning);

--- a/tests/state-gate.test.js
+++ b/tests/state-gate.test.js
@@ -1,0 +1,85 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+const ensureEnv = (key, value) => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+ensureEnv('BOT_TOKEN', 'test-bot-token');
+ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+ensureEnv('KASPI_NAME', 'Test User');
+ensureEnv('KASPI_PHONE', '+70000000000');
+ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+ensureEnv('WEBHOOK_SECRET', 'secret');
+
+const { stateGate } = require('../src/bot/middlewares/stateGate');
+
+test('stateGate allows clients with trial_expired status to continue', async () => {
+  const replies = [];
+
+  const ctx = {
+    chat: { id: 101, type: 'private' },
+    message: { text: 'Оформить доставку' },
+    auth: {
+      user: {
+        role: 'client',
+        status: 'trial_expired',
+        phoneVerified: true,
+      },
+    },
+    session: {},
+    reply: async (text) => {
+      replies.push(text);
+    },
+  };
+
+  const gate = stateGate();
+  let nextCalled = false;
+
+  await gate(ctx, async () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true, 'Client middleware should proceed for trial_expired users');
+  assert.equal(replies.length, 0, 'Client should not receive subscription warnings');
+});
+
+test('stateGate keeps restricting executors with trial_expired status', async () => {
+  const replies = [];
+
+  const ctx = {
+    chat: { id: 102, type: 'private' },
+    message: { text: 'Получить заказы' },
+    auth: {
+      user: {
+        role: 'executor',
+        status: 'trial_expired',
+        phoneVerified: true,
+      },
+    },
+    session: {},
+    reply: async (text) => {
+      replies.push(text);
+    },
+  };
+
+  const gate = stateGate();
+  let nextCalled = false;
+
+  await gate(ctx, async () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false, 'Executor should still be blocked after trial expiration');
+  assert.equal(replies.length, 1, 'Executor should receive a subscription reminder');
+  assert.equal(
+    replies[0],
+    'Пробный период завершён. Продлите подписку, чтобы продолжить получать заказы.',
+    'Executor should see the subscription warning',
+  );
+});


### PR DESCRIPTION
## Summary
- narrow the state gate trial expiration warning to executor accounts
- ensure clients with the legacy trial_expired status continue through middleware
- add regression coverage for both client and executor paths

## Testing
- node --test --test-name-pattern="stateGate" tests/state-gate.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dae9656804832dbbd2cab5a3723157