### PR TITLE
Ensure CRM wizard steps stay within forum threads

### DIFF
--- a/src/bot/channels/commands/from.ts
+++ b/src/bot/channels/commands/from.ts
@@ -316,6 +316,7 @@ const renderPhoneStep = async (
   await ui.step(ctx, {
     id: buildWizardStepId(threadKey, 'phone'),
     text: lines.join('\n'),
+    messageThreadId: state.threadId,
   });
 };
 
@@ -338,6 +339,7 @@ const renderNicknameStep = async (
   await ui.step(ctx, {
     id: buildWizardStepId(threadKey, 'nickname'),
     text: lines.join('\n'),
+    messageThreadId: state.threadId,
   });
 };
 
@@ -361,6 +363,7 @@ const renderPlanStep = async (
     id: buildWizardStepId(threadKey, 'plan'),
     text: lines.join('\n'),
     keyboard: buildPlanChoiceKeyboard(),
+    messageThreadId: state.threadId,
   });
 };
 
@@ -389,6 +392,7 @@ const renderDetailsStep = async (
   await ui.step(ctx, {
     id: buildWizardStepId(threadKey, 'details'),
     text: lines.join('\n'),
+    messageThreadId: state.threadId,
   });
 };
 
@@ -435,6 +439,7 @@ const renderSummaryStep = async (
     id: buildWizardStepId(threadKey, 'summary'),
     text: lines.join('\n'),
     keyboard,
+    messageThreadId: state.threadId,
   });
 };
 
@@ -663,6 +668,7 @@ const handleSummaryDecision = async (
     await ui.step(ctx, {
       id: buildWizardStepId(threadKey, 'summary'),
       text: 'Создание плана отменено.',
+      messageThreadId: state.threadId,
     });
     setWizardState(ctx, threadKey, undefined);
     if (typeof ctx.answerCbQuery === 'function') {
@@ -713,6 +719,7 @@ const handleSummaryDecision = async (
     await ui.step(ctx, {
       id: buildWizardStepId(threadKey, 'summary'),
       text: ['План сохранён ✅', buildPlanSummary(plan)].join('\n\n'),
+      messageThreadId: state.threadId,
     });
     setWizardState(ctx, threadKey, undefined);
 

--- a/src/bot/ui.ts
+++ b/src/bot/ui.ts
@@ -145,6 +145,8 @@ export interface UiStepOptions extends UiTrackOptions {
   homeLabel?: string;
   /** Whether the step should be removed when navigating home. */
   cleanup?: boolean;
+  /** Identifier of the forum topic where the step should be posted. */
+  messageThreadId?: number;
 }
 
 export interface UiStepResult {
@@ -222,6 +224,9 @@ export const ui = {
         : replyMarkup,
       parse_mode: options.parseMode,
       link_preview_options: options.linkPreviewOptions,
+      ...(options.messageThreadId !== undefined
+        ? { message_thread_id: options.messageThreadId }
+        : {}),
     };
 
     let message;

--- a/tests/moderation-form-thread.test.js
+++ b/tests/moderation-form-thread.test.js
@@ -1,0 +1,93 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+function ensureEnv(key, value) {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+}
+
+function enableTestEnv() {
+  ensureEnv('BOT_TOKEN', 'test-bot-token');
+  ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+  ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+  ensureEnv('WEBHOOK_SECRET', 'secret');
+  ensureEnv('BIND_VERIFY_CHANNEL_ID', '777000');
+  ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+  ensureEnv('KASPI_NAME', 'Test User');
+  ensureEnv('KASPI_PHONE', '+70000000000');
+}
+
+enableTestEnv();
+
+const commandModule = require('../src/bot/channels/commands/from');
+const {
+  startWizard,
+  handleWizardTextMessage,
+  handlePlanSelection,
+  getThreadKey,
+} = commandModule.__testing;
+
+test('CRM wizard posts every step inside the originating thread', async () => {
+  const threadId = 4242;
+  const chatId = Number.parseInt(process.env.BIND_VERIFY_CHANNEL_ID, 10);
+  const sentMessages = [];
+  let nextMessageId = 100;
+  let failReplyOnce = true;
+
+  const recordMessage = (method, text, extra = {}, targetChatId = chatId) => {
+    sentMessages.push({ method, text, extra, chatId: targetChatId });
+    return { message_id: nextMessageId++, chat: { id: targetChatId }, text };
+  };
+
+  const ctx = {
+    chat: { id: chatId },
+    message: { message_id: 1, message_thread_id: threadId, text: '/form' },
+    session: {},
+    auth: {},
+    state: {},
+    answerCbQuery: async () => {},
+    reply: async (text, extra = {}) => {
+      if (failReplyOnce) {
+        failReplyOnce = false;
+        const error = new Error('reply message not found');
+        error.description = 'Bad Request: reply message not found';
+        throw error;
+      }
+
+      return recordMessage('reply', text, extra);
+    },
+    telegram: {
+      sendMessage: async (targetChatId, text, extra = {}) =>
+        recordMessage('sendMessage', text, extra, targetChatId),
+      editMessageText: async () => {},
+      deleteMessage: async () => {},
+    },
+  };
+
+  const threadKey = getThreadKey(threadId);
+
+  await startWizard(ctx, threadKey, threadId);
+
+  ctx.message = { message_id: 2, message_thread_id: threadId, text: '+77001234567' };
+  await handleWizardTextMessage(ctx);
+
+  ctx.message = { message_id: 3, message_thread_id: threadId, text: '@executor' };
+  await handleWizardTextMessage(ctx);
+
+  await handlePlanSelection(ctx, threadKey, '7');
+
+  ctx.message = { message_id: 4, message_thread_id: threadId, text: '-' };
+  await handleWizardTextMessage(ctx);
+
+  const expectedPrefixes = ['📞', '👤', '📦', '📝', '📋'];
+
+  for (const prefix of expectedPrefixes) {
+    const message = sentMessages.find((entry) => entry.text.startsWith(prefix));
+    assert.ok(message, `expected step starting with ${prefix}`);
+    assert.equal(message.extra?.message_thread_id, threadId);
+    assert.equal(message.chatId, chatId);
+  }
+});


### PR DESCRIPTION
## Summary
- allow `ui.step` to accept an optional thread id so step messages can target forum topics
- update the CRM wizard to post every prompt into the stored moderator thread
- add a regression test that simulates a thread-bound /form session and checks the posted thread id

## Testing
- node --test tests/moderation-form-thread.test.js

------
https://chatgpt.com/codex/tasks/task_e_68daf5f5f05c832d8abbfff95f83503f