### PR TITLE
Rename from command to form command

### DIFF
--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -245,7 +245,7 @@ const setWizardState = (
 };
 
 const buildWizardStepId = (threadKey: string, step: string): string =>
-  `moderation:from:${threadKey}:${step}`;
+  `moderation:form:${threadKey}:${step}`;
 
 const getWizardStepIds = (threadKey: string): string[] => [
   buildWizardStepId(threadKey, 'phone'),
@@ -784,7 +784,7 @@ const handleMutationWithFallback = async (
   }
 };
 
-const handleFromCommand = async (ctx: BotContext): Promise<void> => {
+const handleFormCommand = async (ctx: BotContext): Promise<void> => {
   if (!ensureVerifyChannel(ctx)) {
     return;
   }
@@ -1063,10 +1063,10 @@ const handleEditCallback = async (ctx: BotContext, planId: number): Promise<void
   await ctx.reply(`Чтобы обновить комментарий, выполните команду:\n/extend ${planId} comment <новый текст>`);
 };
 
-export const registerFromCommand = (bot: Telegraf<BotContext>): void => {
+export const registerFormCommand = (bot: Telegraf<BotContext>): void => {
   VERIFY_COMMANDS.forEach((command) => {
     bot.command(command, async (ctx) => {
-      await handleFromCommand(ctx);
+      await handleFormCommand(ctx);
     });
   });
 

--- a/src/bot/channels/commands/index.ts
+++ b/src/bot/channels/commands/index.ts
@@ -1,8 +1,8 @@
 import type { Telegraf } from 'telegraf';
 
 import type { BotContext } from '../../types';
-import { registerFromCommand } from './from';
+import { registerFormCommand } from './form';
 
 export const registerChannelCommands = (bot: Telegraf<BotContext>): void => {
-  registerFromCommand(bot);
+  registerFormCommand(bot);
 };

--- a/test/formCommand.test.ts
+++ b/test/formCommand.test.ts
@@ -52,6 +52,7 @@ const processedMutations: RecordedMutation[] = [];
         nickname: payload.nickname,
         planChoice: payload.planChoice,
         startAt: payload.startAt,
+        endsAt: payload.endsAt ?? payload.startAt,
         comment: payload.comment,
         status: 'active',
         muted: false,
@@ -106,7 +107,7 @@ process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
 
 void (async () => {
-  const { __testing } = await import('../src/bot/channels/commands/from');
+  const { __testing } = await import('../src/bot/channels/commands/form');
 
   const threadId = 555;
   const threadKey = __testing.getThreadKey(threadId);
@@ -246,7 +247,7 @@ void (async () => {
   );
 
   assert.ok(
-    clearLog.some((entry) => Array.isArray(entry.ids) && entry.ids.includes(`moderation:from:${threadKey}:phone`)),
+    clearLog.some((entry) => Array.isArray(entry.ids) && entry.ids.includes(`moderation:form:${threadKey}:phone`)),
     'Перед финальным сообщением мастер должен очищать промежуточные шаги',
   );
 
@@ -273,5 +274,5 @@ void (async () => {
 
   assert.equal(replies.length, 0, 'Мастер не должен отправлять дополнительные сообщения через reply');
 
-  console.log('from command wizard flow test: OK');
+  console.log('form command wizard flow test: OK');
 })();


### PR DESCRIPTION
## Summary
- rename the channel command module from from.ts to form.ts and update imports
- update moderation step identifiers to use the new form prefix
- adjust the form command test to reference the renamed module and satisfy type requirements

## Testing
- npx ts-node test/formCommand.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db00a1eb7c832d84542de217cf1855