### PR TITLE
Handle thread IDs extracted from channel posts

### DIFF
--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -205,6 +205,14 @@ const getThreadIdFromContext = (ctx: BotContext): number | undefined => {
     }
   }
 
+  const channelPost = ctx.channelPost;
+  if (channelPost && typeof channelPost === 'object' && 'message_thread_id' in channelPost) {
+    const threadId = (channelPost as { message_thread_id?: number }).message_thread_id;
+    if (typeof threadId === 'number') {
+      return threadId;
+    }
+  }
+
   const callbackMessage =
     ctx.callbackQuery && 'message' in ctx.callbackQuery
       ? ctx.callbackQuery.message
@@ -1194,6 +1202,7 @@ export const __testing = {
   parseWizardDetailsInput,
   formatPlanChoiceLabel,
   getThreadKey,
+  getThreadIdFromContext,
   startWizard,
   handleWizardTextMessage,
   handlePlanSelection,

--- a/test/getThreadIdFromContext.test.ts
+++ b/test/getThreadIdFromContext.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+
+declare const process: NodeJS.Process;
+
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+process.env.KASPI_CARD = process.env.KASPI_CARD ?? '1234';
+process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Test User';
+process.env.KASPI_PHONE = process.env.KASPI_PHONE ?? '+70000000000';
+process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
+process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
+process.env.CALLBACK_SIGN_SECRET = process.env.CALLBACK_SIGN_SECRET ?? 'test-secret';
+
+void (async () => {
+  const { __testing } = await import('../src/bot/channels/commands/form');
+
+  const threadId = 321;
+  const ctx = {
+    channelPost: {
+      message_thread_id: threadId,
+    },
+  } as const;
+
+  const result = __testing.getThreadIdFromContext(ctx as unknown as import('../src/bot/types').BotContext);
+
+  assert.equal(result, threadId, 'Thread identifier should be derived from channel posts');
+})();


### PR DESCRIPTION
## Summary
- update getThreadIdFromContext to read message_thread_id from channel_post updates
- expose the helper for tests and cover the channel_post scenario with a unit test

## Testing
- npx ts-node test/getThreadIdFromContext.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db021d2778832db7a1089b699be28b