### PR TITLE
Handle channel post args in form command parser

### DIFF
--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -984,12 +984,15 @@ const handleDeleteCommand = async (ctx: BotContext, args: string[]): Promise<voi
 };
 
 const parseArgs = (ctx: BotContext): string[] => {
-  const message = ctx.message;
-  if (!message || !('text' in message) || !message.text) {
+  const messageText =
+    (ctx.message && 'text' in ctx.message ? ctx.message.text : undefined) ??
+    (ctx.channelPost && 'text' in ctx.channelPost ? ctx.channelPost.text : undefined);
+
+  if (!messageText) {
     return [];
   }
 
-  const text = message.text.trim();
+  const text = messageText.trim();
   const parts = text.split(/\s+/u);
   return parts.slice(1);
 };
@@ -1209,4 +1212,5 @@ export const __testing = {
   handlePlanSelection,
   handleSummaryDecision,
   buildPlanInputFromState,
+  parseArgs,
 };

--- a/test/formCommand.test.ts
+++ b/test/formCommand.test.ts
@@ -355,3 +355,23 @@ void (async () => {
 
   console.log('form command wizard channel_post flow test: OK');
 })();
+
+void (async () => {
+  const { __testing } = await import('../src/bot/channels/commands/form');
+
+  const ctx = {
+    channelPost: {
+      text: '/block 123 Причина блокировки',
+    },
+  } as unknown as BotContext;
+
+  const args = __testing.parseArgs(ctx);
+
+  assert.deepEqual(
+    args,
+    ['123', 'Причина', 'блокировки'],
+    'parseArgs должен корректно разбирать аргументы из channel_post',
+  );
+
+  console.log('form command parseArgs channel_post test: OK');
+})();


### PR DESCRIPTION
## Summary
- allow form command argument parsing to read text from channel posts
- expose the parser helper for testing and cover channel_post argument parsing

## Testing
- npx ts-node test/formCommand.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db03add934832dadf3df9449003ab5