### PR TITLE
Handle executor plan comment edits via inline UI step

### DIFF
--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -102,6 +102,7 @@ const createSupportState = (): SupportSessionState => ({
 
 const createModerationPlansState = (): ModerationPlansSessionState => ({
   threads: {},
+  edits: {},
 });
 
 const USER_ROLES: readonly UserRole[] = ['guest', 'client', 'executor', 'moderator'];

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -240,8 +240,16 @@ export interface ModerationPlanWizardState {
   comment?: string;
 }
 
+export interface ModerationPlanEditState {
+  planId: number;
+  chatId: number;
+  messageId: number;
+  threadId?: number;
+}
+
 export interface ModerationPlansSessionState {
   threads: Record<string, ModerationPlanWizardState | undefined>;
+  edits: Record<string, ModerationPlanEditState | undefined>;
 }
 
 export type SupportRequestStatus = 'idle' | 'awaiting_message';


### PR DESCRIPTION
## Summary
- add session state to track inline executor plan comment edits
- prompt moderators for a new comment via a dedicated UI step and refresh the plan card after saving
- extend the form command test suite to cover the edit flow

## Testing
- npx ts-node test/formCommand.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db0fb149f4832daa447b2afe0385f7