### PR TITLE
Handle timezone-aware parsing for executor plan dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express-rate-limit": "^7.1.5",
         "helmet": "^7.0.0",
         "ioredis": "^5.8.0",
+        "luxon": "^3.7.2",
         "node-cron": "^4.2.1",
         "pg": "^8.16.3",
         "pino": "^9.9.5",
@@ -28,6 +29,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/express-rate-limit": "^6.0.2",
+        "@types/luxon": "^3.3.7",
         "@types/node": "^20.11.17",
         "@types/pg": "^8.15.5",
         "@types/pino": "^7.0.5",
@@ -677,6 +679,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "pino": "^9.9.5",
     "prom-client": "^15.1.3",
     "telegraf": "^4.15.0",
-    "typegram": "^5.2.0"
+    "typegram": "^5.2.0",
+    "luxon": "^3.7.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
@@ -34,6 +35,7 @@
     "@types/node": "^20.11.17",
     "@types/pg": "^8.15.5",
     "@types/pino": "^7.0.5",
+    "@types/luxon": "^3.3.7",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "dbmate": "^2.5.0",

--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -38,6 +38,7 @@ import { setChatCommands } from '../../services/commands';
 import { buildInlineKeyboard, buildConfirmCancelKeyboard } from '../../keyboards/common';
 import { wrapCallbackData } from '../../services/callbackTokens';
 import { buildExecutorPlanActionKeyboard } from '../../ui/executorPlans';
+import { parseDateTimeInTimezone } from '../../../utils/time';
 
 const VERIFY_COMMANDS = ['from', 'form'] as const;
 
@@ -200,8 +201,8 @@ const parseStartDate = (value: string): Date | null => {
     }
   }
 
-  const parsed = new Date(trimmed);
-  if (!Number.isNaN(parsed.getTime())) {
+  const parsed = parseDateTimeInTimezone(trimmed, config.timezone);
+  if (parsed) {
     return parsed;
   }
 

--- a/src/infra/executorPlanQueue.ts
+++ b/src/infra/executorPlanQueue.ts
@@ -16,6 +16,7 @@ import type {
   ExecutorPlanStatus,
 } from '../types';
 import { getRedisClient } from './redis';
+import { parseDateTimeInTimezone } from '../utils/time';
 
 const MUTATION_QUEUE_KEY = 'executor-plan-mutations';
 const MAX_MUTATIONS_PER_FLUSH = 100;
@@ -70,8 +71,7 @@ const parseStartDate = (value: string): Date | null => {
   }
 
   const trimmed = value.trim();
-  const parsed = new Date(trimmed);
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
+  return parseDateTimeInTimezone(trimmed, config.timezone);
 };
 
 const applyMutation = async (
@@ -181,6 +181,10 @@ export const enqueueExecutorPlanMutation = async (
 
   const payload = JSON.stringify(mutation);
   await redis.rpush(getQueueKey(), payload);
+};
+
+export const __testing = {
+  parseStartDate,
 };
 
 export const flushExecutorPlanMutations = async (): Promise<void> => {

--- a/test/parseStartDate.test.ts
+++ b/test/parseStartDate.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { DateTime } from 'luxon';
+
+declare const process: NodeJS.Process;
+
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+process.env.KASPI_CARD = process.env.KASPI_CARD ?? '1234';
+process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Test User';
+process.env.KASPI_PHONE = process.env.KASPI_PHONE ?? '+70000000000';
+process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
+process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
+process.env.CALLBACK_SIGN_SECRET = process.env.CALLBACK_SIGN_SECRET ?? 'test-secret';
+process.env.TIMEZONE = process.env.TIMEZONE ?? 'Asia/Almaty';
+
+const formatInTimezone = (date: Date, timezone: string): string =>
+  DateTime.fromJSDate(date).setZone(timezone).toFormat('yyyy-MM-dd HH:mm:ss');
+
+void (async () => {
+  const [{ __testing: formTesting }, { __testing: queueTesting }, { config }] = await Promise.all([
+    import('../src/bot/channels/commands/form'),
+    import('../src/infra/executorPlanQueue'),
+    import('../src/config'),
+  ]);
+
+  const inputs = ['01.02.2024, 10:00:00', '01.02.2024, 10:00', '01.02.2024 10:00'];
+  const expected = '2024-02-01 10:00:00';
+
+  for (const input of inputs) {
+    const formDate = formTesting.parseStartDate(input);
+    assert.ok(formDate, `Form parser should accept "${input}"`);
+    assert.equal(
+      formatInTimezone(formDate, config.timezone),
+      expected,
+      `Form parser should keep local time for "${input}"`,
+    );
+
+    const queueDate = queueTesting.parseStartDate(input);
+    assert.ok(queueDate, `Queue parser should accept "${input}"`);
+    assert.equal(
+      formatInTimezone(queueDate, config.timezone),
+      expected,
+      `Queue parser should keep local time for "${input}"`,
+    );
+
+    assert.equal(
+      formDate.getTime(),
+      queueDate.getTime(),
+      `Parsers should produce identical timestamps for "${input}"`,
+    );
+  }
+})();


### PR DESCRIPTION
## Summary
- add a luxon-based helper to normalise date/time strings with the configured timezone
- reuse the helper in executor plan date parsing so set-start mutations respect local input
- cover localised date formats with regression tests to ensure no timezone shift

## Testing
- node --require ts-node/register --test test/parseStartDate.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db128a87e0832da17af30938374427