### PR TITLE
Ensure moderation hints are auto-cleaned

### DIFF
--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -39,6 +39,7 @@ import { buildInlineKeyboard, buildConfirmCancelKeyboard } from '../../keyboards
 import { wrapCallbackData } from '../../services/callbackTokens';
 import { buildExecutorPlanActionKeyboard } from '../../ui/executorPlans';
 import { parseDateTimeInTimezone } from '../../../utils/time';
+import { rememberEphemeralMessage } from '../../services/cleanup';
 
 const VERIFY_COMMANDS = ['from', 'form'] as const;
 
@@ -691,7 +692,13 @@ const handleWizardTextMessage = async (ctx: BotContext): Promise<boolean> => {
     case 'phone': {
       const phone = sanitisePhone(text);
       if (!phone) {
-        await ctx.reply('Не удалось распознать номер. Используйте формат +77001234567.');
+        const reply = await ctx.reply('Не удалось распознать номер. Используйте формат +77001234567.');
+        rememberEphemeralMessage(
+          ctx,
+          typeof reply === 'object' && reply !== null && 'message_id' in reply
+            ? (reply as { message_id?: number }).message_id
+            : undefined,
+        );
         return true;
       }
 
@@ -714,7 +721,13 @@ const handleWizardTextMessage = async (ctx: BotContext): Promise<boolean> => {
       return true;
     }
     case 'plan': {
-      await ctx.reply('Выберите тариф с помощью кнопок под сообщением.');
+      const reply = await ctx.reply('Выберите тариф с помощью кнопок под сообщением.');
+      rememberEphemeralMessage(
+        ctx,
+        typeof reply === 'object' && reply !== null && 'message_id' in reply
+          ? (reply as { message_id?: number }).message_id
+          : undefined,
+      );
       return true;
     }
     case 'details':

--- a/test/formCommand.test.ts
+++ b/test/formCommand.test.ts
@@ -193,6 +193,21 @@ void (async () => {
   assert.ok(wizardState, 'Состояние мастера должно создаваться при запуске');
   assert.equal(wizardState?.step, 'phone', 'Первый шаг мастера — ввод телефона');
 
+  setMessage('123');
+  assert.equal(await __testing.handleWizardTextMessage(ctx), true);
+  assert.deepEqual(
+    session.ephemeralMessages,
+    [1],
+    'Подсказка с ошибкой должна сохранять идентификатор для автоудаления',
+  );
+  assert.deepEqual(
+    replies,
+    ['Не удалось распознать номер. Используйте формат +77001234567.'],
+    'При ошибке валидации телефона должна приходить подсказка',
+  );
+  replies.length = 0;
+  session.ephemeralMessages.length = 0;
+
   setMessage('+7 (700) 123-45-67');
   assert.equal(await __testing.handleWizardTextMessage(ctx), true);
 
@@ -207,6 +222,21 @@ void (async () => {
   wizardState = session.moderationPlans.threads[threadKey];
   assert.equal(wizardState?.nickname, '@executor', 'Ник должен сохраняться');
   assert.equal(wizardState?.step, 'plan', 'После ника бот должен ожидать выбор тарифа');
+
+  setMessage('15');
+  assert.equal(await __testing.handleWizardTextMessage(ctx), true);
+  assert.deepEqual(
+    session.ephemeralMessages,
+    [1],
+    'Подсказка о выборе тарифа должна сохранять идентификатор для автоудаления',
+  );
+  assert.deepEqual(
+    replies,
+    ['Выберите тариф с помощью кнопок под сообщением.'],
+    'При попытке отправить тариф текстом должна приходить подсказка',
+  );
+  replies.length = 0;
+  session.ephemeralMessages.length = 0;
 
   await __testing.handlePlanSelection(ctx, threadKey, '15');
   wizardState = session.moderationPlans.threads[threadKey];


### PR DESCRIPTION
## Summary
- remember wizard hint replies for auto cleanup via session ephemeral messages
- cover invalid phone and plan inputs in the form command test suite

## Testing
- npx ts-node test/formCommand.test.ts *(fails: missing luxon type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68db1579189c832da35784be1877b154