### PR TITLE
Handle missing executor reminder queue

### DIFF
--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -15,6 +15,8 @@ import type {
 } from '../../../types';
 import {
   cancelExecutorPlanReminders,
+  ensureExecutorPlanReminderQueue,
+  notifyExecutorPlanReminderQueueUnavailable,
   scheduleExecutorPlanReminder,
 } from '../../../jobs/executorPlanReminders';
 import {
@@ -981,6 +983,15 @@ const handleSummaryDecision = async (
       });
     } catch (error) {
       logger.error({ err: error, planId: plan.id }, 'Failed to post executor plan card');
+    }
+
+    const reminderQueueAvailable = ensureExecutorPlanReminderQueue();
+    if (!reminderQueueAvailable) {
+      await notifyExecutorPlanReminderQueueUnavailable(
+        ctx.telegram,
+        plan.chatId,
+        plan.threadId ?? state.threadId,
+      );
     }
 
     await scheduleExecutorPlanReminder(plan);


### PR DESCRIPTION
## Summary
- add a reusable warning message and notifier for the executor reminder queue and expose a queue availability helper
- notify moderators during plan creation when reminders are disabled instead of silently skipping scheduling
- extend the form command test harness to simulate a missing Redis instance and assert the warning is sent

## Testing
- node --loader ts-node/esm test/formCommand.test.ts *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- npx tsc --noEmit *(terminated early after long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68db1671f7f4832d88ca413dd066ad3e