### PR TITLE
Prevent duplicate executor plans

### DIFF
--- a/src/db/executorPlans.ts
+++ b/src/db/executorPlans.ts
@@ -189,6 +189,26 @@ export const getExecutorPlanById = async (
   return row ? mapRow(row) : null;
 };
 
+export const findActiveExecutorPlanByPhone = async (
+  phone: string,
+  client?: DatabaseClient,
+): Promise<ExecutorPlanRecord | null> => {
+  const db = getClient(client);
+  const { rows } = await db.query<ExecutorPlanRow>(
+    `
+      SELECT *
+      FROM executor_plans
+      WHERE phone = $1 AND status IN ('active', 'blocked')
+      ORDER BY created_at DESC
+      LIMIT 1
+    `,
+    [phone],
+  );
+
+  const [row] = rows;
+  return row ? mapRow(row) : null;
+};
+
 export const updateExecutorPlanReminderIndex = async (
   id: number,
   expectedIndex: number,


### PR DESCRIPTION
## Summary
- add a database helper to load the latest active or blocked executor plan by phone
- prevent the wizard from creating a duplicate plan and surface the existing plan summary to moderators
- extend the form command test suite to cover the duplicate guard

## Testing
- TS_NODE_TRANSPILE_ONLY=1 npx ts-node test/formCommand.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db26af26bc832dafb5682a74b09c32