### PR TITLE
Arrange plan selection keyboard into rows

### DIFF
--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -106,6 +106,7 @@ const MONTHS: Record<string, number> = {
 };
 
 const PLAN_VALUES: ExecutorPlanChoice[] = ['trial', '7', '15', '30'];
+const PLAN_CHOICES_PER_ROW = 2;
 const MS_IN_DAY = 24 * 60 * 60 * 1000;
 
 const CALLBACK_TTL_SECONDS = 7 * 24 * 60 * 60;
@@ -115,7 +116,7 @@ const SUMMARY_CONFIRM_ACTION = `${WIZARD_ACTION_PREFIX}:confirm`;
 const SUMMARY_CANCEL_ACTION = `${WIZARD_ACTION_PREFIX}:cancel`;
 
 const PLAN_SELECT_CALLBACK_PATTERN = new RegExp(
-  `^${PLAN_SELECT_ACTION}:(trial|7|15|30)$`,
+  `^${PLAN_SELECT_ACTION}:(${PLAN_VALUES.join('|')})$`,
 );
 const SUMMARY_CONFIRM_CALLBACK_PATTERN = new RegExp(
   `^${SUMMARY_CONFIRM_ACTION}$`,
@@ -366,15 +367,19 @@ const formatDateTime = (value: Date): string =>
 
 const buildPlanChoiceKeyboard = (): ReturnType<typeof buildInlineKeyboard> => {
   const secret = config.bot.callbackSignSecret ?? config.bot.token;
-  const rows = [
-    PLAN_VALUES.map((choice) => ({
-      label: PLAN_CHOICE_LABELS[choice],
-      action: wrapCallbackData(`${PLAN_SELECT_ACTION}:${choice}`, {
-        secret,
-        ttlSeconds: CALLBACK_TTL_SECONDS,
-      }),
-    })),
-  ];
+  const rows: Array<Array<{ label: string; action: string }>> = [];
+  for (let index = 0; index < PLAN_VALUES.length; index += PLAN_CHOICES_PER_ROW) {
+    const rowValues = PLAN_VALUES.slice(index, index + PLAN_CHOICES_PER_ROW);
+    rows.push(
+      rowValues.map((choice) => ({
+        label: PLAN_CHOICE_LABELS[choice],
+        action: wrapCallbackData(`${PLAN_SELECT_ACTION}:${choice}`, {
+          secret,
+          ttlSeconds: CALLBACK_TTL_SECONDS,
+        }),
+      })),
+    );
+  }
 
   return buildInlineKeyboard(rows);
 };

--- a/test/formCommand.test.ts
+++ b/test/formCommand.test.ts
@@ -277,6 +277,31 @@ void (async () => {
   assert.equal(wizardState?.nickname, '@executor', 'Ник должен сохраняться');
   assert.equal(wizardState?.step, 'plan', 'После ника бот должен ожидать выбор тарифа');
 
+  const planSteps = stepLog.filter((step) => step.id === `moderation:form:${threadKey}:plan`);
+  const planStepEntry = planSteps.at(-1);
+  assert.ok(planStepEntry, 'Шаг выбора тарифа должен отображаться в интерфейсе');
+  const planKeyboard = planStepEntry?.keyboard as
+    | { inline_keyboard?: { text: string }[][] }
+    | undefined;
+  assert.ok(planKeyboard?.inline_keyboard, 'Клавиатура выбора тарифа должна быть доступна');
+  const planButtonLabels = planKeyboard.inline_keyboard.map((row) =>
+    row.map((button) => button.text),
+  );
+  assert.deepEqual(
+    planButtonLabels,
+    [
+      [
+        __testing.formatPlanChoiceLabel('trial'),
+        __testing.formatPlanChoiceLabel('7'),
+      ],
+      [
+        __testing.formatPlanChoiceLabel('15'),
+        __testing.formatPlanChoiceLabel('30'),
+      ],
+    ],
+    'Клавиатура выбора тарифа должна располагать варианты по две кнопки в ряд',
+  );
+
   setMessage('15');
   assert.equal(await __testing.handleWizardTextMessage(ctx), true);
   assert.deepEqual(


### PR DESCRIPTION
## Summary
- chunk plan selection values into two-button rows when building the wizard keyboard
- derive the plan selection callback pattern from the configured values and keep tests aligned with the new layout

## Testing
- npx ts-node --transpile-only test/formCommand.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db28e9e344832d9d3ac2a69c186cf6