### PR TITLE
Store executor plan card message metadata

### DIFF
--- a/db/migrations/0019_executor_plan_card_message.down.sql
+++ b/db/migrations/0019_executor_plan_card_message.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE executor_plans
+  DROP COLUMN IF EXISTS card_message_id,
+  DROP COLUMN IF EXISTS card_chat_id;

--- a/db/migrations/0019_executor_plan_card_message.up.sql
+++ b/db/migrations/0019_executor_plan_card_message.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE executor_plans
+  ADD COLUMN IF NOT EXISTS card_message_id INTEGER,
+  ADD COLUMN IF NOT EXISTS card_chat_id BIGINT;

--- a/src/types/executorPlans.ts
+++ b/src/types/executorPlans.ts
@@ -16,6 +16,8 @@ export interface ExecutorPlanRecord {
   muted: boolean;
   reminderIndex: number;
   reminderLastSent?: Date;
+  cardMessageId?: number;
+  cardChatId?: number;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary
- add a migration that stores executor plan card message and chat identifiers
- persist the moderation card message metadata after posting from the summary handler
- extend the form command test harness to cover saving and reading the card message id

## Testing
- npx ts-node --transpile-only test/formCommand.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db378cb74c832d8b99f7266847ac1e