### PR TITLE
Fix executor plan insert comment parameters and add regression test

### DIFF
--- a/src/db/executorPlans.ts
+++ b/src/db/executorPlans.ts
@@ -157,7 +157,7 @@ export const createExecutorPlan = async (
         created_at,
         updated_at
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, 'active', false, 0, $8, $8)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', false, 0, $9, $9)
       RETURNING *
     `,
     [


### PR DESCRIPTION
## Summary
- fix the executor plan creation SQL to bind the comment parameter while keeping status, muted, and reminder defaults in place
- add a moderation form regression test covering handleSummaryDecision to ensure a plan is persisted with its comment without SQL errors

## Testing
- node --test tests/moderation-form-thread.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db46ec7854832dba7f7b2937b13039