### PR TITLE
Remove trial fields from user records

### DIFF
--- a/db/migrations/0020_remove_user_trial_columns.down.sql
+++ b/db/migrations/0020_remove_user_trial_columns.down.sql
@@ -1,0 +1,26 @@
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS trial_started_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS trial_expires_at TIMESTAMPTZ;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'user_subscription_status'
+  ) THEN
+    ALTER TYPE user_subscription_status RENAME TO user_subscription_status_new;
+
+    CREATE TYPE user_subscription_status AS ENUM ('none', 'trial', 'active', 'grace', 'expired');
+
+    ALTER TABLE users
+      ALTER COLUMN sub_status TYPE user_subscription_status
+      USING sub_status::text::user_subscription_status;
+
+    ALTER TABLE users
+      ALTER COLUMN sub_status SET DEFAULT 'none';
+
+    DROP TYPE user_subscription_status_new;
+  END IF;
+END
+$$;

--- a/db/migrations/0020_remove_user_trial_columns.up.sql
+++ b/db/migrations/0020_remove_user_trial_columns.up.sql
@@ -1,0 +1,30 @@
+ALTER TABLE users
+  DROP COLUMN IF EXISTS trial_started_at,
+  DROP COLUMN IF EXISTS trial_expires_at;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'user_subscription_status'
+  ) THEN
+    UPDATE users
+    SET sub_status = 'active'
+    WHERE sub_status = 'trial';
+
+    ALTER TYPE user_subscription_status RENAME TO user_subscription_status_old;
+
+    CREATE TYPE user_subscription_status AS ENUM ('none', 'active', 'grace', 'expired');
+
+    ALTER TABLE users
+      ALTER COLUMN sub_status TYPE user_subscription_status
+      USING sub_status::text::user_subscription_status;
+
+    ALTER TABLE users
+      ALTER COLUMN sub_status SET DEFAULT 'none';
+
+    DROP TYPE user_subscription_status_old;
+  END IF;
+END
+$$;

--- a/src/bot/channels/membership.ts
+++ b/src/bot/channels/membership.ts
@@ -81,7 +81,6 @@ export const registerMembershipSync = (
         telegramId: userId,
         subscriptionStatus: 'expired',
         subscriptionExpiresAt,
-        trialExpiresAt: null,
         hasActiveOrder: false,
         status: 'trial_expired',
         updatedAt: endedAt,

--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -206,9 +206,14 @@ export const showMenu = async (ctx: BotContext, prompt?: string): Promise<void> 
 
   uiState.pendingCityAction = undefined;
   const cityLabel = CITY_LABEL[city];
-  const trialExpiresAt = ctx.auth.user.trialExpiresAt;
-  const trialDaysLeft = trialExpiresAt
-    ? Math.max(0, Math.ceil((trialExpiresAt.getTime() - Date.now()) / 86400000))
+  const trialPlan =
+    ctx.auth.user.activeExecutorPlan?.planChoice === 'trial'
+      && ctx.auth.user.activeExecutorPlan.status === 'active'
+      ? ctx.auth.user.activeExecutorPlan
+      : undefined;
+  const trialEndsAt = trialPlan?.endsAt;
+  const trialDaysLeft = trialEndsAt
+    ? Math.max(0, Math.ceil((trialEndsAt.getTime() - Date.now()) / 86400000))
     : undefined;
   const baseText = prompt ?? clientMenuText();
   const miniStatus = copy.clientMiniStatus(cityLabel, trialDaysLeft);

--- a/src/bot/services/reports.ts
+++ b/src/bot/services/reports.ts
@@ -34,7 +34,6 @@ interface SubscriptionIdentity extends UserIdentity {
   shortId?: string;
   subscriptionStatus?: UserSubscriptionStatus;
   subscriptionExpiresAt?: Date | number | string;
-  trialExpiresAt?: Date | number | string;
   hasActiveOrder?: boolean;
 }
 
@@ -106,7 +105,6 @@ const formatSubscriptionStatus = (
 
   const labels: Record<UserSubscriptionStatus, string> = {
     none: 'нет подписки',
-    trial: 'пробный период',
     active: 'активна',
     grace: 'льготный период',
     expired: 'истекла',
@@ -125,8 +123,7 @@ const appendSubscriptionDetails = (
     lines.push(`Статус: ${statusLabel}`);
   }
 
-  const expiresSource =
-    subscriber.subscriptionExpiresAt ?? subscriber.trialExpiresAt ?? fallbackExpiresAt;
+  const expiresSource = subscriber.subscriptionExpiresAt ?? fallbackExpiresAt;
   const expiresLabel = formatDateTime(expiresSource);
   if (expiresLabel) {
     lines.push(`Доступ до: ${expiresLabel}`);

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -2,6 +2,7 @@ import type { Context } from 'telegraf';
 
 import type {
   ExecutorPlanChoice,
+  ExecutorPlanStatus,
   OrderLocation,
   OrderPriceDetails,
 } from '../types';
@@ -21,7 +22,15 @@ export type UserRole = 'guest' | 'client' | 'executor' | 'moderator';
 
 export type UserVerifyStatus = 'none' | 'pending' | 'active' | 'rejected' | 'expired';
 
-export type UserSubscriptionStatus = 'none' | 'trial' | 'active' | 'grace' | 'expired';
+export type UserSubscriptionStatus = 'none' | 'active' | 'grace' | 'expired';
+
+export interface AuthExecutorPlan {
+  id: number;
+  planChoice: ExecutorPlanChoice;
+  status: ExecutorPlanStatus;
+  startAt: Date;
+  endsAt: Date;
+}
 
 export interface SessionUser {
   id: number;
@@ -69,9 +78,8 @@ export interface AuthUser {
   isBlocked: boolean;
   citySelected?: AppCity;
   verifiedAt?: Date;
-  trialStartedAt?: Date;
-  trialExpiresAt?: Date;
   subscriptionExpiresAt?: Date;
+  activeExecutorPlan?: AuthExecutorPlan;
   hasActiveOrder: boolean;
   lastMenuRole?: UserMenuRole;
   keyboardNonce?: string;
@@ -101,9 +109,8 @@ export interface AuthStateSnapshot {
   userIsVerified: boolean;
   executor: AuthExecutorState;
   isModerator: boolean;
-  trialStartedAt?: Date;
-  trialExpiresAt?: Date;
   subscriptionExpiresAt?: Date;
+  executorPlan?: AuthExecutorPlan;
   city?: AppCity;
   hasActiveOrder: boolean;
   stale: boolean;

--- a/src/db/subscriptions.ts
+++ b/src/db/subscriptions.ts
@@ -505,8 +505,6 @@ export const activateSubscription = async (
       telegramId,
       subscriptionStatus: 'active',
       subscriptionExpiresAt: periodEnd,
-      trialStartedAt: null,
-      trialExpiresAt: null,
       status: 'active_executor',
       updatedAt: submittedAt,
     });
@@ -620,10 +618,8 @@ export const createTrialSubscription = async (
       await updateUserSubscriptionStatus({
         client,
         telegramId,
-        subscriptionStatus: 'trial',
+        subscriptionStatus: 'active',
         subscriptionExpiresAt: nextBillingAt,
-        trialStartedAt: now,
-        trialExpiresAt: nextBillingAt,
         status: 'active_executor',
         updatedAt: now,
       });
@@ -697,10 +693,8 @@ export const createTrialSubscription = async (
     await updateUserSubscriptionStatus({
       client,
       telegramId,
-      subscriptionStatus: 'trial',
+      subscriptionStatus: 'active',
       subscriptionExpiresAt: nextBillingAt,
-      trialStartedAt: now,
-      trialExpiresAt: nextBillingAt,
       status: 'active_executor',
       updatedAt: now,
     });

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -32,8 +32,6 @@ export interface UpdateUserSubscriptionStatusParams {
   client?: PoolClient;
   subscriptionStatus?: UserSubscriptionStatus;
   subscriptionExpiresAt?: Date | null;
-  trialStartedAt?: Date | null;
-  trialExpiresAt?: Date | null;
   hasActiveOrder?: boolean | null;
   status?: UserStatus;
   updatedAt?: Date;
@@ -199,8 +197,6 @@ export const updateUserSubscriptionStatus = async ({
   client,
   subscriptionStatus,
   subscriptionExpiresAt,
-  trialStartedAt,
-  trialExpiresAt,
   hasActiveOrder,
   status,
   updatedAt,
@@ -218,18 +214,6 @@ export const updateUserSubscriptionStatus = async ({
   if (subscriptionExpiresAt !== undefined) {
     assignments.push(`sub_expires_at = $${index}`);
     values.push(subscriptionExpiresAt);
-    index += 1;
-  }
-
-  if (trialStartedAt !== undefined) {
-    assignments.push(`trial_started_at = $${index}`);
-    values.push(trialStartedAt);
-    index += 1;
-  }
-
-  if (trialExpiresAt !== undefined) {
-    assignments.push(`trial_expires_at = $${index}`);
-    values.push(trialExpiresAt);
     index += 1;
   }
 

--- a/src/db/verifications.ts
+++ b/src/db/verifications.ts
@@ -256,10 +256,6 @@ const applyVerificationDecision = async (
         UPDATE users
         SET verify_status = $2,
             verified_at = CASE WHEN $2 = 'active' THEN now() ELSE verified_at END,
-            trial_started_at = CASE
-              WHEN $2 = 'active' AND trial_started_at IS NULL THEN now()
-              ELSE trial_started_at
-            END,
             updated_at = now()
         WHERE tg_id = $1
       `,

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -251,7 +251,6 @@ const processExpiredSubscriptions = async (
         telegramId: subscription.telegramId,
         subscriptionStatus: 'expired',
         subscriptionExpiresAt: subscription.expiresAt,
-        trialExpiresAt: null,
         hasActiveOrder: false,
         status: 'trial_expired',
         updatedAt: now,

--- a/tests/profile-card.test.js
+++ b/tests/profile-card.test.js
@@ -42,6 +42,7 @@ const createContext = (userOverrides = {}) => {
     isVerified: false,
     isBlocked: false,
     citySelected: 'almaty',
+    activeExecutorPlan: undefined,
     hasActiveOrder: false,
     keyboardNonce: 'nonce1',
   };
@@ -68,9 +69,14 @@ test('buildProfileCardText enriches client profile with statuses and metrics', (
 
   const ctx = createContext({
     verifyStatus: 'pending',
-    subscriptionStatus: 'trial',
-    trialStartedAt: new Date('2030-01-01T00:00:00Z'),
-    trialExpiresAt,
+    subscriptionStatus: 'active',
+    activeExecutorPlan: {
+      id: 101,
+      planChoice: 'trial',
+      status: 'active',
+      startAt: new Date('2030-01-01T00:00:00Z'),
+      endsAt: trialExpiresAt,
+    },
     subscriptionExpiresAt,
     performanceMetrics: {
       ordersCompleted: 12,
@@ -137,8 +143,13 @@ test('buildProfileCardText surfaces executor metrics and navigation', () => {
     verifiedAt: new Date('2024-02-01T00:00:00Z'),
     subscriptionStatus: 'active',
     subscriptionExpiresAt: new Date('2030-02-10T00:00:00Z'),
-    trialStartedAt: new Date('2020-01-01T00:00:00Z'),
-    trialExpiresAt: new Date('2020-01-10T00:00:00Z'),
+    activeExecutorPlan: {
+      id: 202,
+      planChoice: 'trial',
+      status: 'completed',
+      startAt: new Date('2020-01-01T00:00:00Z'),
+      endsAt: new Date('2020-01-10T00:00:00Z'),
+    },
     hasActiveOrder: true,
     performance: {
       rating: 4.8,


### PR DESCRIPTION
## Summary
- add a migration that drops the users.trial_started_at / users.trial_expires_at columns and removes the obsolete "trial" subscription status value
- stop writing user trial timestamps in the DAO layer and surface the active executor plan as the source of truth for trial data throughout auth, session, and profile flows
- update subscription reporting/tests to the new shape and adjust build/test fixtures accordingly

## Testing
- npm run build
- node --test tests/profile-card.test.js
- node --test tests/state-gate.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd73f9df5c832da14fcc494c783743