### PR TITLE
feat: support new subscription and callback env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,15 @@ WEBHOOK_SECRET=__PUT_YOURS__ # Random secret appended to the webhook path for va
 # Optional application settings
 NODE_ENV=development
 LOG_LEVEL=info
+HMAC_SECRET= # Optional secret used for signing callback payloads. Falls back to the bot token when empty.
 SUB_WARN_HOURS_BEFORE=24
+TRIAL_DAYS=2 # Length of the trial period offered to new executors.
+PLAN_DURATIONS=7:7,15:15,30:30 # Overrides for paid plan durations in days (key:value pairs or JSON).
 CITY_DEFAULT=Almaty # Default city appended to short address queries (omit to disable).
 DATABASE_SSL=false
 SENTRY_DSN=
+REDIS_URL=redis://localhost:6379/0 # Enable Redis-backed session cache when provided.
+ORDERS_CHANNEL_ID= # Optional fallback chat ID used for the orders feed when bindings are absent.
 
 # Subscription pricing (overrides defaults when provided)
 SUB_PRICE_7=5000 # Seven-day subscription price in KZT (defaults to 5000).

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -51,14 +51,26 @@ are missing or blank.
 - `SESSION_CACHE_PREFIX` – Prefix appended to Redis keys that store session
   payloads. Defaults to `session:`.
 
+## Callback security
+
+- `HMAC_SECRET` – Overrides the default secret used to sign callback payloads
+  and tokens. When omitted, the bot token is reused for signing. Provide a
+  separate secret to avoid exposing the bot token in other integrations.
+
 ## Subscription settings
 
+- `TRIAL_DAYS` – Duration (in days) of the free trial available to executors. The
+  default is 2 days.
+- `PLAN_DURATIONS` – Overrides for the paid plan lengths. Accepts either a JSON
+  object (for example, `{"7": 14, "15": 21}`) or a comma-separated list of
+  `plan:days` pairs (for example, `7:14,15:21,30:30`). Any plans not listed fall
+  back to the built-in defaults (7, 15 and 30 days respectively).
 - `SUB_PRICE_7`, `SUB_PRICE_15`, `SUB_PRICE_30` – Override subscription prices (in
   KZT) for 7, 15 and 30 day plans. Defaults are 5000, 9000 and 16000 respectively
   when the variables are omitted.
 - `SUB_WARN_HOURS_BEFORE` – Number of hours before expiry when reminder messages are
   sent. Defaults to 24 hours. The value must be a positive number.
-- `DRIVERS_CHANNEL_ID` – Optional numeric identifier used to seed the drivers channel
+- `ORDERS_CHANNEL_ID` – Optional numeric identifier used to seed the orders channel
   binding when `/bind_drivers_channel` has not been executed yet. Provide the full
   chat ID (including the leading `-100` prefix for Telegram supergroups) to skip the
   manual binding step during initial deployments.

--- a/charts/service-bot/values.yaml
+++ b/charts/service-bot/values.yaml
@@ -16,6 +16,8 @@ env:
       secretKeyRef:
         name: service-bot
         key: webhookSecret
+  - name: HMAC_SECRET
+    value: ""
   - name: DATABASE_URL
     value: ""
   - name: SENTRY_DSN
@@ -25,6 +27,14 @@ env:
         key: sentryDsn
   - name: SENTRY_TRACES_SAMPLE_RATE
     value: '0.1'
+  - name: REDIS_URL
+    value: ""
+  - name: TRIAL_DAYS
+    value: "2"
+  - name: PLAN_DURATIONS
+    value: ""
+  - name: ORDERS_CHANNEL_ID
+    value: ""
 ingress:
   enabled: false
   className: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - BOT_TOKEN=${BOT_TOKEN}
       - WEBHOOK_DOMAIN=${WEBHOOK_DOMAIN}
       - WEBHOOK_SECRET=${WEBHOOK_SECRET}
+      - HMAC_SECRET=${HMAC_SECRET:-}
+      - REDIS_URL=${REDIS_URL:-}
+      - TRIAL_DAYS=${TRIAL_DAYS:-2}
+      - PLAN_DURATIONS=${PLAN_DURATIONS:-}
+      - ORDERS_CHANNEL_ID=${ORDERS_CHANNEL_ID:-}
     depends_on:
       - postgres
   postgres:

--- a/src/bot/channels/bindings.ts
+++ b/src/bot/channels/bindings.ts
@@ -77,7 +77,8 @@ const writeToCache = (type: ChannelType, value: ChannelBinding | null): void => 
 };
 
 const FALLBACK_CHAT_IDS: Partial<Record<ChannelType, number>> = {
-  drivers: config.subscriptions.payment.driversChannelId,
+  drivers: config.channels.ordersChannelId,
+  verify: config.channels.bindVerifyChannelId,
 };
 
 const getConfiguredFallbackChatId = (type: ChannelType): number | null => {

--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -371,7 +371,7 @@ const formatDateTime = (value: Date): string =>
   }).format(value);
 
 const buildPlanChoiceKeyboard = (): ReturnType<typeof buildInlineKeyboard> => {
-  const secret = config.bot.callbackSignSecret ?? config.bot.token;
+  const secret = config.bot.hmacSecret ?? config.bot.token;
   const rows: Array<Array<{ label: string; action: string }>> = [];
   for (let index = 0; index < PLAN_VALUES.length; index += PLAN_CHOICES_PER_ROW) {
     const rowValues = PLAN_VALUES.slice(index, index + PLAN_CHOICES_PER_ROW);
@@ -633,7 +633,7 @@ const renderSummaryStep = async (
   lines.push(`Комментарий: ${state.comment ?? '—'}`);
   lines.push('', 'Нажмите «Сохранить», чтобы создать запись, или «Отмена», чтобы сбросить форму.');
 
-  const secret = config.bot.callbackSignSecret ?? config.bot.token;
+  const secret = config.bot.hmacSecret ?? config.bot.token;
   const keyboard = buildConfirmCancelKeyboard(
     wrapCallbackData(SUMMARY_CONFIRM_ACTION, {
       secret,

--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -55,7 +55,7 @@ const UNDO_COMPLETE_ACTION_PREFIX = 'order:undo-complete';
 const UNDO_COMPLETE_ACTION_PATTERN = /^order:undo-complete:(\d+)$/;
 const UNDO_TTL_MS = 2 * 60 * 1000;
 
-const callbackSecret = config.bot.callbackSignSecret ?? config.bot.token;
+const callbackSecret = config.bot.hmacSecret ?? config.bot.token;
 
 const formatOrderType = (kind: OrderKind): string =>
   kind === 'taxi' ? 'Такси' : 'Доставка';

--- a/src/bot/middlewares/callbackDecoder.ts
+++ b/src/bot/middlewares/callbackDecoder.ts
@@ -17,7 +17,7 @@ import {
 } from '../services/callbackTokens';
 import { copy } from '../copy';
 
-const resolveSecret = (): string => config.bot.callbackSignSecret ?? config.bot.token;
+const resolveSecret = (): string => config.bot.hmacSecret ?? config.bot.token;
 
 const handleInvalidCallback = async (ctx: BotContext): Promise<void> => {
   if (typeof ctx.answerCbQuery === 'function') {

--- a/src/bot/moderation/verifyQueue.ts
+++ b/src/bot/moderation/verifyQueue.ts
@@ -335,7 +335,7 @@ const activateVerificationTrial = async (
 
   if (!binding) {
     inviteAvailable = false;
-    const fallbackChatId = config.subscriptions.payment.driversChannelId;
+    const fallbackChatId = config.subscriptions.payment.ordersChannelId;
 
     if (!fallbackChatId) {
       logger.warn(
@@ -358,7 +358,7 @@ const activateVerificationTrial = async (
       lastName: application.applicant.lastName ?? undefined,
       phone: application.applicant.phone ?? undefined,
       executorKind: application.role,
-      chatId: binding?.chatId ?? config.subscriptions.payment.driversChannelId,
+      chatId: binding?.chatId ?? config.subscriptions.payment.ordersChannelId,
       trialDays: DEFAULT_VERIFICATION_TRIAL_DAYS,
       currency: config.subscriptions.prices.currency,
     });

--- a/src/bot/services/callbackTokens.ts
+++ b/src/bot/services/callbackTokens.ts
@@ -348,7 +348,7 @@ export const bindInlineKeyboardToUser = (
     return keyboard;
   }
 
-  const secret = config.bot.callbackSignSecret ?? config.bot.token;
+  const secret = config.bot.hmacSecret ?? config.bot.token;
   if (!secret) {
     return keyboard;
   }

--- a/src/bot/ui/executorPlans.ts
+++ b/src/bot/ui/executorPlans.ts
@@ -22,7 +22,7 @@ const buildExtendAction = (planId: number, days: number, secret: string): string
 export const buildExecutorPlanActionKeyboard = (
   plan: ExecutorPlanRecord,
 ): InlineKeyboardMarkup => {
-  const secret = config.bot.callbackSignSecret ?? config.bot.token;
+  const secret = config.bot.hmacSecret ?? config.bot.token;
 
   const extend7 = buildExtendAction(plan.id, 7, secret);
   const extend15 = buildExtendAction(plan.id, 15, secret);

--- a/src/domain/executorPlans.ts
+++ b/src/domain/executorPlans.ts
@@ -12,17 +12,21 @@ const normaliseDurationDays = (value: number): number => {
 export const getTrialPlanDurationDays = (): number =>
   normaliseDurationDays(config.subscriptions.trialDays);
 
+const isPaidPlanChoice = (choice: ExecutorPlanChoice): choice is '7' | '15' | '30' =>
+  choice !== 'trial';
+
+const getPaidPlanDurationDays = (choice: '7' | '15' | '30'): number =>
+  normaliseDurationDays(config.subscriptions.planDurations[choice]);
+
 export const getPlanChoiceDurationDays = (choice: ExecutorPlanChoice): number => {
   switch (choice) {
     case 'trial':
       return getTrialPlanDurationDays();
-    case '7':
-      return 7;
-    case '15':
-      return 15;
-    case '30':
-      return 30;
     default:
+      if (isPaidPlanChoice(choice)) {
+        return getPaidPlanDurationDays(choice);
+      }
+
       return 7;
   }
 };
@@ -34,11 +38,11 @@ export const getPlanChoiceLabel = (choice: ExecutorPlanChoice): string => {
       return `Пробный план (${days} дн.)`;
     }
     case '7':
-      return 'План на 7 дней';
     case '15':
-      return 'План на 15 дней';
-    case '30':
-      return 'План на 30 дней';
+    case '30': {
+      const days = getPlanChoiceDurationDays(choice);
+      return `План на ${days} дней`;
+    }
     default:
       return `План ${choice} дней`;
   }

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -39,7 +39,7 @@ interface FlowPayloadShape {
   step?: FlowStepPayload;
 }
 
-const secret = config.bot.callbackSignSecret ?? config.bot.token;
+const secret = config.bot.hmacSecret ?? config.bot.token;
 const BATCH_LIMIT = 100;
 const MIN_INACTIVITY_SECONDS = 90;
 

--- a/test/callbackDecoder.test.ts
+++ b/test/callbackDecoder.test.ts
@@ -55,7 +55,7 @@ process.env.SUPPORT_USERNAME = process.env.SUPPORT_USERNAME ?? 'test_support';
 process.env.SUPPORT_URL = process.env.SUPPORT_URL ?? 'https://t.me/test_support';
 process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
-process.env.CALLBACK_SIGN_SECRET = process.env.CALLBACK_SIGN_SECRET ?? 'test-secret';
+process.env.HMAC_SECRET = process.env.HMAC_SECRET ?? 'test-secret';
 
 void (async () => {
   const {

--- a/test/callbackTokens.test.ts
+++ b/test/callbackTokens.test.ts
@@ -43,7 +43,7 @@ process.env.SUPPORT_USERNAME = process.env.SUPPORT_USERNAME ?? 'test_support';
 process.env.SUPPORT_URL = process.env.SUPPORT_URL ?? 'https://t.me/test_support';
 process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
-process.env.CALLBACK_SIGN_SECRET = process.env.CALLBACK_SIGN_SECRET ?? 'test-secret';
+process.env.HMAC_SECRET = process.env.HMAC_SECRET ?? 'test-secret';
 
 void (async () => {
   const {

--- a/test/executorPlanReminders.test.ts
+++ b/test/executorPlanReminders.test.ts
@@ -51,7 +51,7 @@ process.env.SUPPORT_USERNAME = process.env.SUPPORT_USERNAME ?? 'test_support';
 process.env.SUPPORT_URL = process.env.SUPPORT_URL ?? 'https://t.me/test_support';
 process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
-process.env.SUB_TRIAL_DAYS = process.env.SUB_TRIAL_DAYS ?? '3';
+process.env.TRIAL_DAYS = process.env.TRIAL_DAYS ?? '3';
 
 void (async () => {
   const { REMINDER_OFFSETS_HOURS } = await import('../src/services/executorPlans/reminders');
@@ -60,12 +60,11 @@ void (async () => {
 
   const { computeReminderTime } = __testing;
 
-  const PLAN_CONFIGS: Array<{ choice: ExecutorPlanRecord['planChoice']; days: number }> = [
-    { choice: 'trial', days: getPlanChoiceDurationDays('trial') },
-    { choice: '7', days: 7 },
-    { choice: '15', days: 15 },
-    { choice: '30', days: 30 },
-  ];
+  const PLAN_CHOICES: ExecutorPlanRecord['planChoice'][] = ['trial', '7', '15', '30'];
+  const PLAN_CONFIGS = PLAN_CHOICES.map((choice) => ({
+    choice,
+    days: getPlanChoiceDurationDays(choice),
+  }));
 
   const msPerHour = 60 * 60 * 1000;
   const msPerDay = 24 * msPerHour;

--- a/test/formCommand.test.ts
+++ b/test/formCommand.test.ts
@@ -248,7 +248,7 @@ const clearLog: { ids?: string[]; cleanupOnly?: boolean }[] = [];
 
 process.env.NODE_ENV = 'test';
 process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
-process.env.CALLBACK_SIGN_SECRET = process.env.CALLBACK_SIGN_SECRET ?? 'test-secret';
+process.env.HMAC_SECRET = process.env.HMAC_SECRET ?? 'test-secret';
 process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
 process.env.KASPI_CARD = process.env.KASPI_CARD ?? '1234';
 process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Test User';
@@ -257,7 +257,7 @@ process.env.SUPPORT_USERNAME = process.env.SUPPORT_USERNAME ?? 'test_support';
 process.env.SUPPORT_URL = process.env.SUPPORT_URL ?? 'https://t.me/test_support';
 process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
-process.env.SUB_TRIAL_DAYS = process.env.SUB_TRIAL_DAYS ?? '3';
+process.env.TRIAL_DAYS = process.env.TRIAL_DAYS ?? '3';
 
 void (async () => {
   const { __testing } = await import('../src/bot/channels/commands/form');

--- a/test/getThreadIdFromContext.test.ts
+++ b/test/getThreadIdFromContext.test.ts
@@ -12,7 +12,7 @@ process.env.SUPPORT_USERNAME = process.env.SUPPORT_USERNAME ?? 'test_support';
 process.env.SUPPORT_URL = process.env.SUPPORT_URL ?? 'https://t.me/test_support';
 process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
-process.env.CALLBACK_SIGN_SECRET = process.env.CALLBACK_SIGN_SECRET ?? 'test-secret';
+process.env.HMAC_SECRET = process.env.HMAC_SECRET ?? 'test-secret';
 
 void (async () => {
   const { __testing } = await import('../src/bot/channels/commands/form');

--- a/test/parseStartDate.test.ts
+++ b/test/parseStartDate.test.ts
@@ -13,7 +13,7 @@ process.env.SUPPORT_USERNAME = process.env.SUPPORT_USERNAME ?? 'test_support';
 process.env.SUPPORT_URL = process.env.SUPPORT_URL ?? 'https://t.me/test_support';
 process.env.WEBHOOK_DOMAIN = process.env.WEBHOOK_DOMAIN ?? 'example.com';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'secret';
-process.env.CALLBACK_SIGN_SECRET = process.env.CALLBACK_SIGN_SECRET ?? 'test-secret';
+process.env.HMAC_SECRET = process.env.HMAC_SECRET ?? 'test-secret';
 process.env.TIMEZONE = process.env.TIMEZONE ?? 'Asia/Almaty';
 
 const formatInTimezone = (date: Date, timezone: string): string =>


### PR DESCRIPTION
## Summary
- add parsing for TRIAL_DAYS, PLAN_DURATIONS, ORDERS_CHANNEL_ID and HMAC_SECRET in the runtime configuration
- derive executor plan durations and callback HMAC usage from the updated environment values
- refresh environment samples, deployment manifests and tests to use the new variable names

## Testing
- npm run build *(fails: Export declaration conflicts with exported declaration of 'ExecutorOrderAccessPrimaryData')*


------
https://chatgpt.com/codex/tasks/task_e_68dd7f75177c832db085dade58691bb0