### PR TITLE
feat: allow configuring plan durations from env

### DIFF
--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -11,7 +11,7 @@ import {
 } from './menu';
 import { ui } from '../../ui';
 import {
-  SUBSCRIPTION_PERIOD_OPTIONS,
+  getSubscriptionPeriodOptions,
   formatSubscriptionAmount,
 } from './subscriptionPlans';
 import { presentRolePick } from '../../commands/start';
@@ -38,7 +38,7 @@ const buildSubscriptionInfoText = (ctx: BotContext): string => {
   }
 
   const roleCopy = getExecutorRoleCopy(role);
-  const planLines = SUBSCRIPTION_PERIOD_OPTIONS.map((option) =>
+  const planLines = getSubscriptionPeriodOptions().map((option) =>
     buildPlanLine(option.label, option.amount, option.currency),
   );
 
@@ -56,7 +56,7 @@ const buildSubscriptionInfoText = (ctx: BotContext): string => {
 };
 
 const buildSubscriptionKeyboard = () => {
-  const planRows = SUBSCRIPTION_PERIOD_OPTIONS.map((option) => [
+  const planRows = getSubscriptionPeriodOptions().map((option) => [
     Markup.button.url(option.label, SUPPORT_LINK),
   ]);
 

--- a/src/bot/flows/executor/subscriptionPlans.ts
+++ b/src/bot/flows/executor/subscriptionPlans.ts
@@ -1,4 +1,5 @@
 import { config } from '../../../config';
+import { getDayNoun, getPlanChoiceDurationDays } from '../../../domain/executorPlans';
 
 export interface SubscriptionPeriodOption {
   id: string;
@@ -12,34 +13,37 @@ export interface SubscriptionPeriodOption {
   currency: string;
 }
 
-export const SUBSCRIPTION_PERIOD_OPTIONS: readonly SubscriptionPeriodOption[] = [
-  {
-    id: '7',
-    label: '7 дней',
-    days: 7,
-    amount: config.subscriptions.prices.sevenDays,
+type PaidSubscriptionPlanId = '7' | '15' | '30';
+type SubscriptionPriceKey = 'sevenDays' | 'fifteenDays' | 'thirtyDays';
+
+const PLAN_PRICE_KEYS: Record<PaidSubscriptionPlanId, SubscriptionPriceKey> = {
+  '7': 'sevenDays',
+  '15': 'fifteenDays',
+  '30': 'thirtyDays',
+};
+
+const buildSubscriptionPeriodOption = (id: PaidSubscriptionPlanId): SubscriptionPeriodOption => {
+  const days = getPlanChoiceDurationDays(id);
+  const priceKey = PLAN_PRICE_KEYS[id];
+
+  return {
+    id,
+    label: `${days} ${getDayNoun(days)}`,
+    days,
+    amount: config.subscriptions.prices[priceKey],
     currency: config.subscriptions.prices.currency,
-  },
-  {
-    id: '15',
-    label: '15 дней',
-    days: 15,
-    amount: config.subscriptions.prices.fifteenDays,
-    currency: config.subscriptions.prices.currency,
-  },
-  {
-    id: '30',
-    label: '30 дней',
-    days: 30,
-    amount: config.subscriptions.prices.thirtyDays,
-    currency: config.subscriptions.prices.currency,
-  },
-] as const;
+  };
+};
+
+const PLAN_IDS: readonly PaidSubscriptionPlanId[] = ['7', '15', '30'];
+
+export const getSubscriptionPeriodOptions = (): readonly SubscriptionPeriodOption[] =>
+  PLAN_IDS.map((id) => buildSubscriptionPeriodOption(id));
 
 export const findSubscriptionPeriodOption = (
   id: string | undefined,
 ): SubscriptionPeriodOption | undefined =>
-  SUBSCRIPTION_PERIOD_OPTIONS.find((option) => option.id === id);
+  getSubscriptionPeriodOptions().find((option) => option.id === id);
 
 export const formatSubscriptionAmount = (
   amount: number,

--- a/src/bot/services/executorAccess.ts
+++ b/src/bot/services/executorAccess.ts
@@ -267,4 +267,3 @@ export const hasExecutorOrderAccess = async (executorId: number): Promise<boolea
   return access.hasPhone && !access.isBlocked;
 };
 
-export type { ExecutorOrderAccessRecord, ExecutorOrderAccessPrimaryData };

--- a/src/domain/executorPlans.ts
+++ b/src/domain/executorPlans.ts
@@ -1,22 +1,63 @@
 import { config } from '../config';
 import type { ExecutorPlanChoice } from '../types';
 
-const normaliseDurationDays = (value: number): number => {
-  if (!Number.isFinite(value) || value <= 0) {
-    return 1;
+type PaidExecutorPlanChoice = Exclude<ExecutorPlanChoice, 'trial'>;
+
+const PAID_PLAN_CHOICES: readonly PaidExecutorPlanChoice[] = ['7', '15', '30'];
+
+const DEFAULT_PAID_PLAN_DURATIONS: Record<PaidExecutorPlanChoice, number> = {
+  '7': 7,
+  '15': 15,
+  '30': 30,
+};
+
+const PLAN_INDEX_BY_CHOICE: Record<PaidExecutorPlanChoice, number> = {
+  '7': 0,
+  '15': 1,
+  '30': 2,
+};
+
+let planDurationsOverride: readonly number[] | null = null;
+
+const normaliseDurationDays = (value: number, fallback = 1): number => {
+  if (!Number.isFinite(value)) {
+    return fallback;
   }
 
-  return Math.max(1, Math.round(value));
+  const rounded = Math.round(value);
+  if (rounded <= 0) {
+    return fallback;
+  }
+
+  return rounded;
 };
+
+const getConfiguredPlanDurations = (): readonly number[] =>
+  planDurationsOverride ?? config.domain.planDurations;
 
 export const getTrialPlanDurationDays = (): number =>
   normaliseDurationDays(config.subscriptions.trialDays);
 
-const isPaidPlanChoice = (choice: ExecutorPlanChoice): choice is '7' | '15' | '30' =>
+const isPaidPlanChoice = (choice: ExecutorPlanChoice): choice is PaidExecutorPlanChoice =>
   choice !== 'trial';
 
-const getPaidPlanDurationDays = (choice: '7' | '15' | '30'): number =>
-  normaliseDurationDays(config.subscriptions.planDurations[choice]);
+const getPaidPlanDurationDays = (choice: PaidExecutorPlanChoice): number => {
+  const index = PLAN_INDEX_BY_CHOICE[choice];
+  const fallback = DEFAULT_PAID_PLAN_DURATIONS[choice];
+
+  if (typeof index !== 'number') {
+    return fallback;
+  }
+
+  const durations = getConfiguredPlanDurations();
+  const candidate = durations[index];
+
+  if (!Number.isFinite(candidate)) {
+    return fallback;
+  }
+
+  return normaliseDurationDays(candidate, fallback);
+};
 
 export const getPlanChoiceDurationDays = (choice: ExecutorPlanChoice): number => {
   switch (choice) {
@@ -31,6 +72,21 @@ export const getPlanChoiceDurationDays = (choice: ExecutorPlanChoice): number =>
   }
 };
 
+export const getDayNoun = (days: number): string => {
+  const mod10 = days % 10;
+  const mod100 = days % 100;
+
+  if (mod10 === 1 && mod100 !== 11) {
+    return 'день';
+  }
+
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) {
+    return 'дня';
+  }
+
+  return 'дней';
+};
+
 export const getPlanChoiceLabel = (choice: ExecutorPlanChoice): string => {
   switch (choice) {
     case 'trial': {
@@ -41,9 +97,19 @@ export const getPlanChoiceLabel = (choice: ExecutorPlanChoice): string => {
     case '15':
     case '30': {
       const days = getPlanChoiceDurationDays(choice);
-      return `План на ${days} дней`;
+      return `План на ${days} ${getDayNoun(days)}`;
     }
     default:
       return `План ${choice} дней`;
   }
+};
+
+export const __testing__ = {
+  setPlanDurationsOverride: (values: readonly number[] | null): void => {
+    planDurationsOverride = values;
+  },
+  resetPlanDurationsOverride: (): void => {
+    planDurationsOverride = null;
+  },
+  getPaidPlanChoices: (): readonly PaidExecutorPlanChoice[] => PAID_PLAN_CHOICES,
 };

--- a/tests/executor-plan-durations.test.js
+++ b/tests/executor-plan-durations.test.js
@@ -1,0 +1,69 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+const ensureEnv = (key, value) => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+ensureEnv('BOT_TOKEN', 'test-bot-token');
+ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+ensureEnv('KASPI_NAME', 'Test User');
+ensureEnv('KASPI_PHONE', '+70000000000');
+ensureEnv('SUPPORT_USERNAME', 'test_support');
+ensureEnv('SUPPORT_URL', 'https://t.me/test_support');
+ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+ensureEnv('WEBHOOK_SECRET', 'secret');
+
+const executorPlans = require('../src/domain/executorPlans');
+const subscriptionPlans = require('../src/bot/flows/executor/subscriptionPlans');
+const subscriptionFlow = require('../src/bot/flows/executor/subscription');
+
+const createExecutorContext = () => ({
+  session: {},
+  auth: {
+    user: {
+      executorKind: 'courier',
+    },
+  },
+});
+
+test('custom plan durations propagate through subscription prompts', (t) => {
+  executorPlans.__testing__.setPlanDurationsOverride([10, 21, 45]);
+  t.after(() => {
+    executorPlans.__testing__.resetPlanDurationsOverride();
+  });
+
+  assert.equal(executorPlans.getPlanChoiceDurationDays('7'), 10);
+  assert.equal(executorPlans.getPlanChoiceDurationDays('15'), 21);
+  assert.equal(executorPlans.getPlanChoiceDurationDays('30'), 45);
+  assert.equal(executorPlans.getPlanChoiceLabel('7'), 'План на 10 дней');
+  assert.equal(executorPlans.getPlanChoiceLabel('15'), 'План на 21 день');
+  assert.equal(executorPlans.getPlanChoiceLabel('30'), 'План на 45 дней');
+
+  const options = subscriptionPlans.getSubscriptionPeriodOptions();
+  assert.deepEqual(
+    options.map((option) => option.days),
+    [10, 21, 45],
+    'Subscription options should reuse configured durations',
+  );
+  assert.deepEqual(
+    options.map((option) => option.label),
+    ['10 дней', '21 день', '45 дней'],
+    'Subscription option labels should match configured durations',
+  );
+
+  const ctx = createExecutorContext();
+  const infoText = subscriptionFlow.__private__.buildSubscriptionInfoText(ctx);
+  assert.match(infoText, /10 дней/);
+  assert.match(infoText, /21 день/);
+  assert.match(infoText, /45 дней/);
+
+  const keyboard = subscriptionFlow.__private__.buildSubscriptionKeyboard();
+  const planLabels = keyboard.inline_keyboard.slice(0, 3).map((row) => row[0].text);
+  assert.deepEqual(planLabels, ['10 дней', '21 день', '45 дней']);
+});


### PR DESCRIPTION
## Summary
- parse PLAN_DURATIONS overrides into a numeric list and expose it under config.domain
- update executor plan helpers and subscription UI to respect configured durations with proper pluralisation
- add coverage for custom plan durations and clean up an unused executor access type export

## Testing
- npm run build
- node --test tests/executor-plan-durations.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd88624d84832da827edb4cec47260