### PR TITLE
Remove trial countdown from menu copy

### DIFF
--- a/src/bot/copy.ts
+++ b/src/bot/copy.ts
@@ -23,19 +23,14 @@ export const copy = {
   errorGeneric: 'Произошёл сбой. Попробуйте повторить действие чуть позже.',
   invalidPhone: (example = '+7 777 123-45-67') => `Уточните телефон в формате E.164 (пример: ${example}).`,
   statusLine: (emoji: string, text: string) => `${emoji} ${text}`,
-  clientMiniStatus: (cityLabel?: string, trialDaysLeft?: number) =>
-    [
-      cityLabel ? `🏙️ Город: ${cityLabel}` : null,
-      (trialDaysLeft ?? 0) > 0 ? `🧪 Пробный: осталось ${trialDaysLeft} дн.` : null,
-    ].filter(Boolean).join('\n'),
+  clientMiniStatus: (cityLabel?: string) =>
+    [cityLabel ? `🏙️ Город: ${cityLabel}` : null].filter(Boolean).join('\n'),
   executorMiniStatus: (
     cityLabel: string | undefined,
     docs: { uploaded: number; required: number },
-    trialDaysLeft?: number,
   ) =>
     [
       cityLabel ? `🏙️ Город: ${cityLabel}` : null,
-      (trialDaysLeft ?? 0) > 0 ? `🧪 Пробный: осталось ${trialDaysLeft} дн.` : null,
       `🛡️ Документы: ${docs.uploaded}/${docs.required}`,
     ].filter(Boolean).join('\n'),
   orderChannelCard: (kind: 'taxi' | 'delivery', price: string, city: string) =>

--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -206,17 +206,8 @@ export const showMenu = async (ctx: BotContext, prompt?: string): Promise<void> 
 
   uiState.pendingCityAction = undefined;
   const cityLabel = CITY_LABEL[city];
-  const trialPlan =
-    ctx.auth.user.activeExecutorPlan?.planChoice === 'trial'
-      && ctx.auth.user.activeExecutorPlan.status === 'active'
-      ? ctx.auth.user.activeExecutorPlan
-      : undefined;
-  const trialEndsAt = trialPlan?.endsAt;
-  const trialDaysLeft = trialEndsAt
-    ? Math.max(0, Math.ceil((trialEndsAt.getTime() - Date.now()) / 86400000))
-    : undefined;
   const baseText = prompt ?? clientMenuText();
-  const miniStatus = copy.clientMiniStatus(cityLabel, trialDaysLeft);
+  const miniStatus = copy.clientMiniStatus(cityLabel);
   const header = miniStatus ? `${miniStatus}\n\n${baseText}` : baseText;
 
   if (ctx.callbackQuery) {


### PR DESCRIPTION
## Summary
- drop trial countdown lines from shared copy helpers
- simplify client menu mini status rendering to omit trial calculations

## Testing
- node --test tests *(fails: buildProgressKeyboard/ensureExecutorReady/attemptClaimOrder/handleIncomingPhoto missing exports; verification prompt assertion; existing baseline issues)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8da6d694832da8e07b7858041abb