### PR TITLE
Extend executor access cache TTL and coverage

### DIFF
--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -1433,6 +1433,7 @@ const handleStatusCallback = async (
 
     await ctx.answerCbQuery('Статус обновлён');
     await refreshPlanCardMessage(ctx, outcome.plan);
+    await refreshExecutorOrderAccessCacheForPlan(outcome.plan);
     if (targetStatus !== 'blocked') {
       await scheduleExecutorPlanReminder(outcome.plan);
     }

--- a/src/bot/flows/common/phoneCollect.ts
+++ b/src/bot/flows/common/phoneCollect.ts
@@ -1,7 +1,7 @@
 import { Markup, type MiddlewareFn } from 'telegraf';
 import type { ReplyKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
-import { logger } from '../../../config';
+import { config, logger } from '../../../config';
 import { pool } from '../../../db/client';
 import { setUserBlockedStatus } from '../../../db/users';
 import {
@@ -35,7 +35,7 @@ const PHONE_FOREIGN_CONTACT_TEXT = [
 
 const PHONE_STEP_ACTIONS = ['📲 Поделиться контактом', PHONE_HELP_BUTTON_LABEL, PHONE_STATUS_BUTTON_LABEL];
 
-const EXECUTOR_ACCESS_CACHE_TTL_SECONDS = 60 * 60; // 1 hour to survive extended outages.
+const EXECUTOR_ACCESS_CACHE_TTL_SECONDS = config.bot.executorAccessCacheTtlSeconds; // Use configured TTL to survive extended outages.
 
 const rememberEphemeralMessage = (ctx: BotContext, messageId?: number): void => {
   if (!messageId) {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -410,6 +410,7 @@ export interface AppConfig {
     token: string;
     hmacSecret: string;
     callbackTtlSeconds: number;
+    executorAccessCacheTtlSeconds: number;
   };
   features: {
     trialEnabled: boolean;
@@ -507,6 +508,10 @@ export const loadConfig = (): AppConfig => {
       token: process.env.BOT_TOKEN as string,
       hmacSecret: getRequiredString('HMAC_SECRET'),
       callbackTtlSeconds: parsePositiveInt('CALLBACK_TTL_SECONDS', 600),
+      executorAccessCacheTtlSeconds: parsePositiveInt(
+        'EXECUTOR_ACCESS_CACHE_TTL_SECONDS',
+        6 * 60 * 60,
+      ),
     },
     features: {
       trialEnabled: parseBoolean(process.env.FEATURE_TRIAL_ENABLED, true),

--- a/src/infra/userPhoneQueue.ts
+++ b/src/infra/userPhoneQueue.ts
@@ -68,7 +68,9 @@ export const flushUserPhoneUpdates = async (): Promise<void> => {
     try {
       await persistPhoneVerification(update);
       try {
-        await updateCachedExecutorAccess(update.telegramId, { phone: update.phone });
+        await updateCachedExecutorAccess(update.telegramId, { phone: update.phone }, {
+          ttlSeconds: config.bot.executorAccessCacheTtlSeconds,
+        });
       } catch (cacheError) {
         logger.warn(
           { err: cacheError, telegramId: update.telegramId },


### PR DESCRIPTION
## Summary
- make the executor access cache TTL configurable via environment and reuse it across the bot
- refresh executor order access cache on status and phone update events to keep long-lived entries in sync
- adjust and extend the executor access tests to cover configurable TTL and long idle behaviour

## Testing
- node --test --test-name-pattern "executor access cache TTL" tests/executor-order-access.test.js
- node --test --test-name-pattern "uses cached snapshot" tests/executor-order-access.test.js
- node --test tests/phone-collect.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd90f735a4832d9bf202f4a6761a5f