### PR TITLE
Document required HMAC secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Required configuration
 BOT_TOKEN=__PUT_YOURS__
+HMAC_SECRET=__GENERATE_AT_LEAST_32BYTE_RANDOM_SECRET__ # Required secret for signing payloads (use base64 or hex output).
 DATABASE_URL=__PUT_YOURS__
 KASPI_CARD=__PUT_YOURS__ # Kaspi Gold card number presented to subscribers.
 KASPI_NAME=__PUT_YOURS__ # Account holder name shown with the Kaspi payment details.
@@ -12,7 +13,6 @@ WEBHOOK_SECRET=__PUT_YOURS__ # Random secret appended to the webhook path for va
 # Optional application settings
 NODE_ENV=development
 LOG_LEVEL=info
-HMAC_SECRET= # Optional secret used for signing callback payloads. Falls back to the bot token when empty.
 SUB_WARN_HOURS_BEFORE=24
 TRIAL_DAYS=2 # Length of the trial period offered to new executors.
 PLAN_DURATIONS=7:7,15:15,30:30 # Overrides for paid plan durations in days (key:value pairs or JSON).

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -9,8 +9,10 @@ These variables must be present; the application will refuse to start if any of 
 are missing or blank.
 
 - `BOT_TOKEN` – Telegram bot token obtained via [@BotFather](https://t.me/BotFather).
-- `HMAC_SECRET` – Secret key used to sign callback payloads and tokens. Generate a
-  long random string and keep it separate from the bot token.
+- `HMAC_SECRET` – Secret key used to sign callback payloads and tokens. Generate at
+  least 32 bytes of cryptographically strong random data (for example via
+  `openssl rand -hex 32` or `openssl rand -base64 32`) and keep it separate from the
+  bot token.
 - `DATABASE_URL` – PostgreSQL connection string used by the application layer.
 - `KASPI_CARD` – Kaspi Gold card number shown in the subscription instructions.
 - `KASPI_NAME` – Account holder name displayed alongside the Kaspi details.


### PR DESCRIPTION
## Summary
- require a concrete placeholder for `HMAC_SECRET` in the sample environment file and clarify the mandatory comment
- expand the environment reference with guidance on generating a strong HMAC secret

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd99a9857c832d9347d880db09b543