### PR TITLE
Document CRM bind verification channel variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ SUPPORT_USERNAME=__PUT_YOURS__ # Telegram username (without @) of the human supp
 SUPPORT_URL=__PUT_YOURS__ # Full URL linking to the support contact or channel.
 WEBHOOK_DOMAIN=__PUT_YOURS__ # Public domain used for Telegram webhook registration.
 WEBHOOK_SECRET=__PUT_YOURS__ # Random secret appended to the webhook path for validation.
+BIND_VERIFY_CHANNEL_ID= # Numeric Telegram chat ID of the CRM moderation chat (`bind_verify_channel`).
 
 # Optional application settings
 NODE_ENV=development

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -25,6 +25,9 @@ are missing or blank.
   endpoint (for example, `https://bot.example.com`).
 - `WEBHOOK_SECRET` – Secret token appended to the webhook path to prevent unsolicited
   requests. Use a sufficiently long random string.
+- `BIND_VERIFY_CHANNEL_ID` – Numeric identifier of the CRM moderation chat bound as
+  `bind_verify_channel`. Provide the full Telegram chat ID (including the `-100`
+  prefix for supergroups) to ensure verification requests land in the right place.
 
 ## Database options
 


### PR DESCRIPTION
## Summary
- add the `BIND_VERIFY_CHANNEL_ID` placeholder to the required environment sample with CRM chat context
- document the bind verification channel requirement in the environment guide so moderation setup is covered

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ddaa29d154832da15566926d282aa6