### PR TITLE
Ensure verify channel shows command menu

### DIFF
--- a/src/bot/channels/commands/form.ts
+++ b/src/bot/channels/commands/form.ts
@@ -88,9 +88,7 @@ const ensureVerifyChannelCommands = (bot: Telegraf<BotContext>): void => {
     }
 
     try {
-      await setChatCommands(bot.telegram, chatId, VERIFY_CHANNEL_COMMANDS, {
-        showMenuButton: false,
-      });
+      await setChatCommands(bot.telegram, chatId, VERIFY_CHANNEL_COMMANDS);
     } catch (error) {
       logger.error({ err: error, chatId }, 'Failed to register verify channel commands');
     }

--- a/src/bot/services/commands.ts
+++ b/src/bot/services/commands.ts
@@ -36,6 +36,7 @@ export const setChatCommands = async (
       chatId,
       menuButton: { type: 'commands' },
     });
+    logger.info({ chatId }, 'Chat menu button set to commands');
   } catch (error) {
     logger.warn({ err: error, chatId }, 'Failed to set chat menu button');
   }


### PR DESCRIPTION
## Summary
- allow the verify channel command registration to enable the chat menu button
- log when the chat menu button is successfully configured for commands

## Testing
- npm run build *(fails: npm is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc0846d3c832da4d15169e0acec05