### PR TITLE
Fix migration handling for user trial removal

### DIFF
--- a/db/migrations/0020_remove_user_trial_columns.down.sql
+++ b/db/migrations/0020_remove_user_trial_columns.down.sql
@@ -14,6 +14,9 @@ BEGIN
     CREATE TYPE user_subscription_status AS ENUM ('none', 'trial', 'active', 'grace', 'expired');
 
     ALTER TABLE users
+      ALTER COLUMN sub_status DROP DEFAULT;
+
+    ALTER TABLE users
       ALTER COLUMN sub_status TYPE user_subscription_status
       USING sub_status::text::user_subscription_status;
 

--- a/db/migrations/0020_remove_user_trial_columns.up.sql
+++ b/db/migrations/0020_remove_user_trial_columns.up.sql
@@ -9,6 +9,9 @@ BEGIN
     FROM pg_type
     WHERE typname = 'user_subscription_status'
   ) THEN
+    ALTER TYPE user_subscription_status
+      ADD VALUE IF NOT EXISTS 'trial';
+
     UPDATE users
     SET sub_status = 'active'
     WHERE sub_status = 'trial';
@@ -16,6 +19,9 @@ BEGIN
     ALTER TYPE user_subscription_status RENAME TO user_subscription_status_old;
 
     CREATE TYPE user_subscription_status AS ENUM ('none', 'active', 'grace', 'expired');
+
+    ALTER TABLE users
+      ALTER COLUMN sub_status DROP DEFAULT;
 
     ALTER TABLE users
       ALTER COLUMN sub_status TYPE user_subscription_status


### PR DESCRIPTION
## Summary
- drop the sub_status default before changing its enum and restore the default afterwards
- ensure the legacy enum label exists before updating users and keep the down migration symmetrical

## Testing
- `for file in $(ls db/migrations/*.up.sql | sort); do echo "Applying $file"; sudo -u postgres psql -v ON_ERROR_STOP=1 -d bot_clean -f "$file" >/tmp/psql.log && tail -n 5 /tmp/psql.log; done`
- `for file in $(ls db/migrations/*.up.sql | sort); do if [[ "$file" == *"0020"* ]]; then break; fi; echo "Applying $file"; sudo -u postgres psql -v ON_ERROR_STOP=1 -d bot_existing -f "$file" >/tmp/psql_existing.log && tail -n 5 /tmp/psql_existing.log; done`
- `echo "Applying db/migrations/0020_remove_user_trial_columns.up.sql"; sudo -u postgres psql -v ON_ERROR_STOP=1 -d bot_existing -f db/migrations/0020_remove_user_trial_columns.up.sql >/tmp/psql_existing.log && tail -n 5 /tmp/psql_existing.log`
- `echo "Reverting db/migrations/0020_remove_user_trial_columns.down.sql"; sudo -u postgres psql -v ON_ERROR_STOP=1 -d bot_existing -f db/migrations/0020_remove_user_trial_columns.down.sql >/tmp/psql_existing.log && tail -n 5 /tmp/psql_existing.log`

------
https://chatgpt.com/codex/tasks/task_e_68ddce95de2c832da072b4d83c318a5a