### PR TITLE
Handle keyboard nonce updates for client callbacks

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -114,10 +114,11 @@ export const applyClientRole = async (ctx: BotContext): Promise<void> => {
   const shouldPreserveStatus = restrictedStatuses.has(authUser.status);
 
   const nextStatus = shouldPreserveStatus ? authUser.status : 'active_client';
+  let ensuredKeyboardNonce: string | undefined;
 
   if (shouldEnsureRole || shouldUpdatePhone) {
     try {
-      await ensureClientRole({
+      ensuredKeyboardNonce = await ensureClientRole({
         telegramId: authUser.telegramId,
         username: username ?? undefined,
         firstName: firstName ?? undefined,
@@ -137,6 +138,9 @@ export const applyClientRole = async (ctx: BotContext): Promise<void> => {
   authUser.username = username ?? undefined;
   authUser.firstName = firstName ?? undefined;
   authUser.lastName = lastName ?? undefined;
+  if (!authUser.keyboardNonce && ensuredKeyboardNonce) {
+    authUser.keyboardNonce = ensuredKeyboardNonce;
+  }
   if (phone) {
     authUser.phone = phone;
     authUser.phoneVerified = true;

--- a/src/bot/services/callbackTokens.ts
+++ b/src/bot/services/callbackTokens.ts
@@ -325,9 +325,24 @@ export const verifyCallbackForUser = (
   }
 
   const encodedUser = safeBase36(user.telegramId);
-  const encodedNonce = sanitiseKeyboardNonce(resolveKeyboardNonce(user));
+  const resolvedNonce = resolveKeyboardNonce(user);
+  const encodedNonce = sanitiseKeyboardNonce(resolvedNonce);
+  const fallbackNonce = deriveFallbackKeyboardNonce(user.telegramId);
+  const encodedFallbackNonce = fallbackNonce ? sanitiseKeyboardNonce(fallbackNonce) : undefined;
 
-  return wrapped.user === encodedUser && wrapped.nonce === encodedNonce;
+  if (wrapped.user !== encodedUser) {
+    return false;
+  }
+
+  if (wrapped.nonce === encodedNonce) {
+    return true;
+  }
+
+  if (encodedFallbackNonce && wrapped.nonce === encodedFallbackNonce) {
+    return true;
+  }
+
+  return false;
 };
 
 const hasCallbackData = (

--- a/tests/stats-reports-flows.test.js
+++ b/tests/stats-reports-flows.test.js
@@ -118,7 +118,7 @@ test('applyClientRole reports client role assignment', { concurrency: false }, a
   const { applyClientRole } = require('../src/bot/flows/client/menu');
 
   const originalEnsureClientRole = dbUsers.ensureClientRole;
-  dbUsers.ensureClientRole = async () => {};
+  dbUsers.ensureClientRole = async () => 'test-keyboard-nonce';
   t.after(() => {
     dbUsers.ensureClientRole = originalEnsureClientRole;
   });


### PR DESCRIPTION
## Summary
- return the persisted keyboard nonce from ensureClientRole so callers can sync auth state
- preserve the ensured nonce in the client auth snapshot and tolerate fallback nonces when verifying callbacks
- cover nonce rotations with a regression test and update existing mocks to reflect the new API

## Testing
- npx ts-node test/callbackTokens.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dde9cb9464832d83ff070fa3894fe0