### PR TITLE
Await callback surrogate persistence

### DIFF
--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -537,7 +537,7 @@ const buildAlreadyProcessedResponse = (state: OrderChannelState): string => {
   return copy.orderAlreadyTakenToast;
 };
 
-const buildActionKeyboard = (order: OrderRecord): InlineKeyboardMarkup => {
+const buildActionKeyboard = async (order: OrderRecord): Promise<InlineKeyboardMarkup> => {
   const locationsKeyboard = buildOrderLocationsKeyboard(order.city, order.pickup, order.dropoff);
   const acceptRaw = `${ACCEPT_ACTION_PREFIX}:${order.id}`;
   const declineRaw = `${DECLINE_ACTION_PREFIX}:${order.id}`;
@@ -545,7 +545,7 @@ const buildActionKeyboard = (order: OrderRecord): InlineKeyboardMarkup => {
     [
       {
         label: '✅ Беру заказ',
-        action: wrapCallbackData(acceptRaw, {
+        action: await wrapCallbackData(acceptRaw, {
           secret: callbackSecret,
           bindToUser: false,
           ttlSeconds: config.bot.callbackTtlSeconds,
@@ -555,7 +555,7 @@ const buildActionKeyboard = (order: OrderRecord): InlineKeyboardMarkup => {
     [
       {
         label: '❌ Недоступен',
-        action: wrapCallbackData(declineRaw, {
+        action: await wrapCallbackData(declineRaw, {
           secret: callbackSecret,
           bindToUser: false,
           ttlSeconds: config.bot.callbackTtlSeconds,
@@ -601,7 +601,7 @@ export const publishOrderToDriversChannel = async (
           } satisfies PublishOrderResult;
         }
 
-        const keyboard = buildActionKeyboard(order);
+        const keyboard = await buildActionKeyboard(order);
         const message = await telegram.sendMessage(chatId, messageText, {
           reply_markup: keyboard,
         });

--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -234,7 +234,7 @@ export const showMenu = async (ctx: BotContext, prompt?: string): Promise<void> 
       [{ label: copy.refresh, action: CLIENT_MENU_REFRESH_ACTION }],
     ];
 
-    const keyboard = bindInlineKeyboardToUser(ctx, buildInlineKeyboard(rows));
+    const keyboard = await bindInlineKeyboardToUser(ctx, buildInlineKeyboard(rows));
 
     try {
       await ctx.editMessageText(header, { reply_markup: keyboard });

--- a/src/bot/flows/common/profileCard.ts
+++ b/src/bot/flows/common/profileCard.ts
@@ -195,10 +195,10 @@ export const buildProfileCardText = (ctx: BotContext): string => {
   return lines.join('\n');
 };
 
-const buildProfileCardKeyboard = (
+const buildProfileCardKeyboard = async (
   ctx: BotContext,
   options: ProfileCardNavigationOptions,
-): InlineKeyboardMarkup | undefined => {
+): Promise<InlineKeyboardMarkup | undefined> => {
   const rows: KeyboardButton[][] = [];
 
   if (options.changeCityAction) {
@@ -264,7 +264,7 @@ export const renderProfileCard = async (
   }
 
   const text = buildProfileCardText(ctx);
-  const reply_markup = buildProfileCardKeyboard(ctx, options);
+  const reply_markup = await buildProfileCardKeyboard(ctx, options);
 
   const message = ctx.callbackQuery?.message;
   if (message && 'message_id' in message && typeof message.message_id === 'number') {

--- a/src/bot/ui.ts
+++ b/src/bot/ui.ts
@@ -188,7 +188,7 @@ export const ui = {
 
     const existing = state.steps[options.id];
     if (isInlineKeyboard(replyMarkup)) {
-      replyMarkup = bindInlineKeyboardToUser(ctx, replyMarkup);
+      replyMarkup = await bindInlineKeyboardToUser(ctx, replyMarkup);
     }
     if (existing && existing.chatId === chatId && isInlineKeyboard(replyMarkup)) {
       try {
@@ -219,9 +219,7 @@ export const ui = {
     }
 
     const extra = {
-      reply_markup: isInlineKeyboard(replyMarkup)
-        ? bindInlineKeyboardToUser(ctx, replyMarkup)
-        : replyMarkup,
+      reply_markup: replyMarkup,
       parse_mode: options.parseMode,
       link_preview_options: options.linkPreviewOptions,
       ...(options.messageThreadId !== undefined

--- a/src/bot/ui/executorPlans.ts
+++ b/src/bot/ui/executorPlans.ts
@@ -13,34 +13,34 @@ import { wrapCallbackData } from '../services/callbackTokens';
 
 const CALLBACK_TTL_SECONDS = 7 * 24 * 60 * 60;
 
-const buildExtendAction = (planId: number, days: number, secret: string): string =>
+const buildExtendAction = async (planId: number, days: number, secret: string): Promise<string> =>
   wrapCallbackData(`${EXECUTOR_PLAN_EXTEND_ACTION}:${planId}:${days}`, {
     secret,
     ttlSeconds: CALLBACK_TTL_SECONDS,
   });
 
-export const buildExecutorPlanActionKeyboard = (
+export const buildExecutorPlanActionKeyboard = async (
   plan: ExecutorPlanRecord,
-): InlineKeyboardMarkup => {
+): Promise<InlineKeyboardMarkup> => {
   const secret = config.bot.hmacSecret;
 
-  const extend7 = buildExtendAction(plan.id, 7, secret);
-  const extend15 = buildExtendAction(plan.id, 15, secret);
-  const extend30 = buildExtendAction(plan.id, 30, secret);
+  const extend7 = await buildExtendAction(plan.id, 7, secret);
+  const extend15 = await buildExtendAction(plan.id, 15, secret);
+  const extend30 = await buildExtendAction(plan.id, 30, secret);
 
-  const blockAction = wrapCallbackData(`${EXECUTOR_PLAN_BLOCK_ACTION}:${plan.id}`, {
+  const blockAction = await wrapCallbackData(`${EXECUTOR_PLAN_BLOCK_ACTION}:${plan.id}`, {
     secret,
     ttlSeconds: CALLBACK_TTL_SECONDS,
   });
-  const unblockAction = wrapCallbackData(`${EXECUTOR_PLAN_UNBLOCK_ACTION}:${plan.id}`, {
+  const unblockAction = await wrapCallbackData(`${EXECUTOR_PLAN_UNBLOCK_ACTION}:${plan.id}`, {
     secret,
     ttlSeconds: CALLBACK_TTL_SECONDS,
   });
-  const toggleMuteAction = wrapCallbackData(`${EXECUTOR_PLAN_TOGGLE_MUTE_ACTION}:${plan.id}`, {
+  const toggleMuteAction = await wrapCallbackData(`${EXECUTOR_PLAN_TOGGLE_MUTE_ACTION}:${plan.id}`, {
     secret,
     ttlSeconds: CALLBACK_TTL_SECONDS,
   });
-  const editAction = wrapCallbackData(`${EXECUTOR_PLAN_EDIT_ACTION}:${plan.id}`, {
+  const editAction = await wrapCallbackData(`${EXECUTOR_PLAN_EDIT_ACTION}:${plan.id}`, {
     secret,
     ttlSeconds: CALLBACK_TTL_SECONDS,
   });

--- a/src/jobs/executorPlanReminders.ts
+++ b/src/jobs/executorPlanReminders.ts
@@ -166,7 +166,7 @@ const postReminderMessage = async (
   reminderIndex: number,
 ): Promise<void> => {
   const message = buildReminderMessage(plan, reminderIndex);
-  const keyboard = buildExecutorPlanActionKeyboard(plan);
+  const keyboard = await buildExecutorPlanActionKeyboard(plan);
 
   try {
     await telegram.sendMessage(plan.chatId, message, {

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -143,11 +143,11 @@ const buildNudgeText = (payload: FlowPayloadShape): string => {
   return segments.join('\n\n');
 };
 
-const bindAction = (
+const bindAction = async (
   action: string,
   userId: string | null,
   keyboardNonce: string | null,
-): string => {
+): Promise<string> => {
   const shouldBind = Boolean(userId && keyboardNonce);
 
   return wrapCallbackData(action, {
@@ -159,19 +159,19 @@ const bindAction = (
   });
 };
 
-const buildNudgeKeyboard = (
+const buildNudgeKeyboard = async (
   payload: FlowPayloadShape,
   role: string | null,
   userId: string | null,
   keyboardNonce: string | null,
-): InlineKeyboardMarkup | undefined => {
+): Promise<InlineKeyboardMarkup | undefined> => {
   const rows: { label: string; action: string }[][] = [];
 
   if (payload.homeAction) {
     rows.push([
       {
         label: copy.resume,
-        action: bindAction(payload.homeAction, userId, keyboardNonce),
+        action: await bindAction(payload.homeAction, userId, keyboardNonce),
       },
     ]);
   }
@@ -187,7 +187,7 @@ const buildNudgeKeyboard = (
     rows.push([
       {
         label: copy.home,
-        action: bindAction(fallbackAction, userId, keyboardNonce),
+        action: await bindAction(fallbackAction, userId, keyboardNonce),
       },
     ]);
   }
@@ -222,7 +222,7 @@ const deliverNudge = async (bot: Telegraf<BotContext>, row: PendingSessionRow): 
   }
 
   const payload = parseFlowPayload(row.flow_payload);
-  const keyboard = buildNudgeKeyboard(
+  const keyboard = await buildNudgeKeyboard(
     payload,
     row.role,
     sessionKey.scopeId,

--- a/test/callbackTokens.test.ts
+++ b/test/callbackTokens.test.ts
@@ -22,6 +22,9 @@ const callbackStore = new Map<string, {
       payload: unknown;
       expiresAt: Date;
     }): Promise<void> => {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       callbackStore.set(record.token, { ...record });
     },
     loadCallbackMapRecord: async (token: string): Promise<unknown> =>
@@ -59,7 +62,7 @@ void (async () => {
 
   const secret = 'test-secret';
 
-  const wrapped = wrapCallbackData(ROLE_PICK_EXECUTOR_ACTION, {
+  const wrapped = await wrapCallbackData(ROLE_PICK_EXECUTOR_ACTION, {
     secret,
     userId: 987654321,
     keyboardNonce: 'n',
@@ -83,7 +86,7 @@ void (async () => {
 
   let oversizeOutcome: import('../src/bot/services/callbackTokens').WrapCallbackOutcome | undefined;
   const longRaw = 'x'.repeat(130);
-  const oversizeWrapped = wrapCallbackData(longRaw, {
+  const oversizeWrapped = await wrapCallbackData(longRaw, {
     secret,
     userId: 111111,
     keyboardNonce: 'nonce-value',
@@ -155,7 +158,7 @@ void (async () => {
       inline_keyboard: [[{ text: 'Orders', callback_data: 'client:orders:list' }]],
     };
 
-    const bound = bindInlineKeyboardToUser(
+    const bound = await bindInlineKeyboardToUser(
       ctx as unknown as import('../src/bot/types').BotContext,
       keyboard,
     );
@@ -220,7 +223,7 @@ void (async () => {
       },
     };
 
-    boundKeyboard = bindInlineKeyboardToUser(
+    boundKeyboard = await bindInlineKeyboardToUser(
       ctx as unknown as import('../src/bot/types').BotContext,
       keyboard,
     );


### PR DESCRIPTION
## Summary
- await callback surrogate persistence in wrapCallbackData and propagate the async signature through keyboard binding
- update bot channels, UI helpers, and jobs to await surrogate wrapping when building inline keyboards
- expand callback surrogate tests with asynchronous persistence stubs and an immediate decode regression check

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddf12a5634832da8ea441f3541d578