### PR TITLE
Use crypto randomness for short IDs

### DIFF
--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -1,10 +1,12 @@
+import { randomInt as cryptoRandomInt } from 'node:crypto';
+
 const DEFAULT_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
 const DEFAULT_LENGTH = 8;
 
 const isAlphabetValid = (alphabet: string): boolean =>
   Boolean(alphabet) && new Set(alphabet).size === alphabet.length;
 
-const randomInt = (max: number): number => Math.floor(Math.random() * max);
+const randomIndex = (max: number): number => cryptoRandomInt(max);
 
 export interface ShortIdOptions {
   /** Custom alphabet used to generate IDs. Defaults to base36 characters. */
@@ -25,7 +27,7 @@ export const createShortId = (options: ShortIdOptions = {}): string => {
 
   let id = '';
   for (let index = 0; index < length; index += 1) {
-    id += alphabet[randomInt(alphabet.length)];
+    id += alphabet[randomIndex(alphabet.length)];
   }
 
   return id;


### PR DESCRIPTION
## Summary
- generate short IDs with `crypto.randomInt` to avoid Math.random usage

## Testing
- npx ts-node test/callbackTokens.test.ts
- npx ts-node test/callbackDecoder.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de728c5bac832d80924a49f7bb6b75