### PR TITLE
Handle missing callback nonce sanitisation

### DIFF
--- a/src/bot/services/callbackTokens.ts
+++ b/src/bot/services/callbackTokens.ts
@@ -345,6 +345,19 @@ export const verifyCallbackForUser = (
     return true;
   }
 
+  const sanitisedNonceMissing = !wrapped.nonce && !encodedNonce && !encodedFallbackNonce;
+  if (sanitisedNonceMissing) {
+    logger.debug(
+      {
+        telegramId: user.telegramId,
+        action: wrapped.raw,
+        version: wrapped.version,
+      },
+      'Accepting callback for user without nonce after sanitisation',
+    );
+    return true;
+  }
+
   return false;
 };
 


### PR DESCRIPTION
## Summary
- accept callbacks for the correct user when sanitisation removes the nonce and log a debug diagnostic event
- add a regression test covering dash-only keyboard nonces to ensure wrapping omits nonce metadata and verification succeeds

## Testing
- npx ts-node test/callbackTokens.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de92b33718832d86b3ab96655e2a2c