### PR TITLE
Handle empty keyboard nonce sanitisation

### DIFF
--- a/src/bot/services/callbackTokens.ts
+++ b/src/bot/services/callbackTokens.ts
@@ -331,18 +331,10 @@ export const verifyCallbackForUser = (
   const resolvedNonce = resolveKeyboardNonce(user);
   const encodedNonce = sanitiseKeyboardNonce(resolvedNonce);
   const fallbackNonce = deriveFallbackKeyboardNonce(user.telegramId);
-  const encodedFallbackNonce = fallbackNonce ? sanitiseKeyboardNonce(fallbackNonce) : undefined;
+  const encodedFallbackNonce = sanitiseKeyboardNonce(fallbackNonce);
 
   if (wrapped.user !== encodedUser) {
     return false;
-  }
-
-  if (wrapped.nonce === encodedNonce) {
-    return true;
-  }
-
-  if (encodedFallbackNonce && wrapped.nonce === encodedFallbackNonce) {
-    return true;
   }
 
   const sanitisedNonceMissing = !wrapped.nonce && !encodedNonce && !encodedFallbackNonce;
@@ -355,6 +347,14 @@ export const verifyCallbackForUser = (
       },
       'Accepting callback for user without nonce after sanitisation',
     );
+    return true;
+  }
+
+  if (wrapped.nonce === encodedNonce) {
+    return true;
+  }
+
+  if (encodedFallbackNonce && wrapped.nonce === encodedFallbackNonce) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- accept callbacks whose sanitised keyboard nonce is empty while logging the event before fallback checks
- ensure fallback nonce sanitisation always runs and regression test captures the debug log for dashed keyboard nonces

## Testing
- node -r ts-node/register test/callbackTokens.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dea1d33750832db093072d2d5b38ba