### PR TITLE
Handle missing nonce callbacks when sanitized value is empty

### DIFF
--- a/src/bot/services/callbackTokens.ts
+++ b/src/bot/services/callbackTokens.ts
@@ -337,8 +337,7 @@ export const verifyCallbackForUser = (
     return false;
   }
 
-  const sanitisedNonceMissing = !wrapped.nonce && !encodedNonce && !encodedFallbackNonce;
-  if (sanitisedNonceMissing) {
+  if (!wrapped.nonce && !encodedNonce) {
     logger.debug(
       {
         telegramId: user.telegramId,


### PR DESCRIPTION
## Summary
- accept callbacks that have no nonce when the current keyboard nonce sanitises to an empty string
- log the acceptance before any fallback checks to preserve previous behaviour
- add a regression test covering callbacks with dashed keyboard nonces and a populated fallback nonce

## Testing
- npx ts-node test/callbackTokens.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dea7c923cc832da623eab3d2b30592