### PR TITLE
Use inline keyboard for client menu actions

### DIFF
--- a/src/bot/flows/client/deliveryOrderFlow.ts
+++ b/src/bot/flows/client/deliveryOrderFlow.ts
@@ -36,8 +36,8 @@ import {
 import { buildOrderLocationsKeyboard } from '../../keyboards/orders';
 import type { BotContext, ClientOrderDraftState } from '../../types';
 import { ui } from '../../ui';
-import { CLIENT_MENU, isClientChat, sendClientMenu } from '../../../ui/clientMenu';
-import { CLIENT_MENU_ACTION, logClientMenuClick } from './menu';
+import { CLIENT_MENU_ACTION, sendClientMenu } from '../../../ui/clientMenu';
+import { logClientMenuClick } from './menu';
 import { CLIENT_DELIVERY_ORDER_AGAIN_ACTION, CLIENT_ORDERS_ACTION } from './orderActions';
 import { ensureCitySelected } from '../common/citySelect';
 import type { AppCity } from '../../../domain/cities';
@@ -1319,14 +1319,6 @@ export const registerDeliveryOrderFlow = (bot: Telegraf<BotContext>): void => {
     }
 
     await handleRecentDropoff(ctx, locationId);
-  });
-
-  bot.hears(CLIENT_MENU.delivery, async (ctx) => {
-    if (!isClientChat(ctx, ctx.auth?.user.role)) {
-      return;
-    }
-
-    await handleStart(ctx);
   });
 
   bot.command('delivery', async (ctx) => {

--- a/src/bot/flows/client/orders.ts
+++ b/src/bot/flows/client/orders.ts
@@ -14,8 +14,8 @@ import { formatDistance, formatEtaMinutes, formatPriceAmount } from '../../servi
 import type { BotContext } from '../../types';
 import type { OrderStatus, OrderWithExecutor } from '../../../types';
 import { ui } from '../../ui';
-import { sendClientMenu } from '../../../ui/clientMenu';
-import { CLIENT_MENU_ACTION, logClientMenuClick } from './menu';
+import { CLIENT_MENU_ACTION, sendClientMenu } from '../../../ui/clientMenu';
+import { logClientMenuClick } from './menu';
 import {
   CLIENT_CANCEL_ORDER_ACTION_PATTERN,
   CLIENT_CANCEL_ORDER_ACTION_PREFIX,

--- a/src/bot/flows/client/taxiOrderFlow.ts
+++ b/src/bot/flows/client/taxiOrderFlow.ts
@@ -32,8 +32,8 @@ import {
 import { buildOrderLocationsKeyboard } from '../../keyboards/orders';
 import type { BotContext, ClientOrderDraftState } from '../../types';
 import { ui } from '../../ui';
-import { CLIENT_MENU, isClientChat, sendClientMenu } from '../../../ui/clientMenu';
-import { CLIENT_MENU_ACTION, logClientMenuClick } from './menu';
+import { CLIENT_MENU_ACTION, sendClientMenu } from '../../../ui/clientMenu';
+import { logClientMenuClick } from './menu';
 import { CLIENT_TAXI_ORDER_AGAIN_ACTION, CLIENT_ORDERS_ACTION } from './orderActions';
 import { ensureCitySelected } from '../common/citySelect';
 import type { AppCity } from '../../../domain/cities';
@@ -865,14 +865,6 @@ export const registerTaxiOrderFlow = (bot: Telegraf<BotContext>): void => {
     }
 
     await handleRecentDropoff(ctx, locationId);
-  });
-
-  bot.hears(CLIENT_MENU.taxi, async (ctx) => {
-    if (!isClientChat(ctx, ctx.auth?.user.role)) {
-      return;
-    }
-
-    await handleStart(ctx);
   });
 
   bot.command('taxi', async (ctx) => {

--- a/src/bot/ui/menus.ts
+++ b/src/bot/ui/menus.ts
@@ -1,24 +1,18 @@
 import { Markup } from 'telegraf';
 
-import { CLIENT_MENU } from '../../ui/clientMenu';
+import { CLIENT_MENU_TRIGGER } from '../../ui/clientMenu';
 import type { BotContext } from '../types';
 import { EXECUTOR_MENU_TEXT_LABELS } from '../flows/executor/menu';
 import { isSafeModeSession } from '../flows/common/safeMode';
 import { showSafeModeCard } from './safeModeCard';
 
-export const CLIENT_WHITELIST: Set<string> = new Set(Object.values(CLIENT_MENU));
+export const CLIENT_WHITELIST: Set<string> = new Set([CLIENT_MENU_TRIGGER]);
 export const EXECUTOR_WHITELIST: Set<string> = new Set(
   Object.values(EXECUTOR_MENU_TEXT_LABELS),
 );
 
 export const clientKeyboard = () =>
-  Markup.keyboard([
-    [CLIENT_MENU.taxi, CLIENT_MENU.delivery],
-    [CLIENT_MENU.orders],
-    [CLIENT_MENU.support, CLIENT_MENU.city],
-    [CLIENT_MENU.switchRole],
-    [CLIENT_MENU.refresh],
-  ])
+  Markup.keyboard([[CLIENT_MENU_TRIGGER]])
     .resize()
     .persistent();
 

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -3,7 +3,7 @@ import type { Telegraf } from 'telegraf';
 import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
 import type { BotContext } from '../bot/types';
-import { CLIENT_MENU_ACTION } from '../bot/flows/client/menu';
+import { CLIENT_MENU_ACTION } from '../ui/clientMenu';
 import { EXECUTOR_MENU_ACTION } from '../bot/flows/executor/menu';
 import { buildInlineKeyboard } from '../bot/keyboards/common';
 import { wrapCallbackData } from '../bot/services/callbackTokens';

--- a/src/ui/clientMenu.ts
+++ b/src/ui/clientMenu.ts
@@ -1,9 +1,14 @@
 import { Markup } from 'telegraf';
 import type { Telegram } from 'telegraf';
-import type { Message } from 'telegraf/typings/core/types/typegram';
+import type { InlineKeyboardMarkup, Message } from 'telegraf/typings/core/types/typegram';
 
 import type { BotContext, UserRole } from '../bot/types';
 import { PROFILE_BUTTON_LABEL } from '../bot/flows/common/profileCard';
+import { CLIENT_ORDERS_ACTION } from '../bot/flows/client/orderActions';
+import { START_DELIVERY_ORDER_ACTION } from '../bot/flows/client/deliveryOrderFlow';
+import { START_TAXI_ORDER_ACTION } from '../bot/flows/client/taxiOrderFlow';
+import { buildInlineKeyboard } from '../bot/keyboards/common';
+import { bindInlineKeyboardToUser } from '../bot/services/callbackTokens';
 
 export const CLIENT_MENU = {
   taxi: '🚕 Заказать такси',
@@ -16,36 +21,86 @@ export const CLIENT_MENU = {
   refresh: '🔄 Обновить меню',
 } as const;
 
+export const CLIENT_MENU_TRIGGER = '🎯 Меню';
+
+export const CLIENT_MENU_ACTION = 'client:menu:show';
+export const CLIENT_MENU_REFRESH_ACTION = 'client:menu:refresh';
+export const CLIENT_MENU_SUPPORT_ACTION = 'client:menu:support';
+export const CLIENT_MENU_CITY_SELECT_ACTION = 'client:menu:city';
+export const CLIENT_MENU_SWITCH_ROLE_ACTION = 'client:menu:switch-role';
+export const CLIENT_MENU_PROFILE_ACTION = 'client:menu:profile';
+
+type ClientMenuButton = { label: string; action: string };
+
+const CLIENT_MENU_ROWS: ClientMenuButton[][] = [
+  [
+    { label: CLIENT_MENU.taxi, action: START_TAXI_ORDER_ACTION },
+    { label: CLIENT_MENU.delivery, action: START_DELIVERY_ORDER_ACTION },
+  ],
+  [
+    { label: CLIENT_MENU.orders, action: CLIENT_ORDERS_ACTION },
+    { label: CLIENT_MENU.profile, action: CLIENT_MENU_PROFILE_ACTION },
+  ],
+  [
+    { label: CLIENT_MENU.support, action: CLIENT_MENU_SUPPORT_ACTION },
+    { label: CLIENT_MENU.city, action: CLIENT_MENU_CITY_SELECT_ACTION },
+  ],
+  [{ label: CLIENT_MENU.switchRole, action: CLIENT_MENU_SWITCH_ROLE_ACTION }],
+  [{ label: CLIENT_MENU.refresh, action: CLIENT_MENU_REFRESH_ACTION }],
+];
+
 const buildKeyboard = (): ReturnType<typeof Markup.keyboard> =>
-  Markup.keyboard([
-    [CLIENT_MENU.taxi, CLIENT_MENU.delivery],
-    [CLIENT_MENU.orders, CLIENT_MENU.profile],
-    [CLIENT_MENU.support, CLIENT_MENU.city],
-    [CLIENT_MENU.switchRole],
-    [CLIENT_MENU.refresh],
-  ])
+  Markup.keyboard([[CLIENT_MENU_TRIGGER]])
     .resize()
     .persistent();
+
+const buildInlineMenuKeyboard = (): InlineKeyboardMarkup => buildInlineKeyboard(CLIENT_MENU_ROWS);
+
+export const buildClientMenuKeyboard = async (
+  ctx: BotContext,
+): Promise<InlineKeyboardMarkup | undefined> => bindInlineKeyboardToUser(ctx, buildInlineMenuKeyboard());
+
+const buildCombinedMenuMarkup = (
+  replyMarkup: ReturnType<typeof buildKeyboard>,
+  inlineKeyboard: InlineKeyboardMarkup | undefined,
+) => {
+  if (!inlineKeyboard) {
+    return replyMarkup;
+  }
+
+  const replyKeyboard = replyMarkup.reply_markup ?? {};
+  return {
+    reply_markup: {
+      ...replyKeyboard,
+      inline_keyboard: inlineKeyboard.inline_keyboard,
+    },
+  };
+};
 
 const DEFAULT_MENU_PROMPT = 'Что дальше? Выберите действие:';
 
 export const sendClientMenu = async (
   ctx: BotContext,
   text: string = DEFAULT_MENU_PROMPT,
+  inlineKeyboard?: InlineKeyboardMarkup,
 ): Promise<Message.TextMessage | undefined> => {
   if (!ctx.chat) {
     return undefined;
   }
 
+  const replyKeyboard = buildKeyboard();
+  const resolvedInlineKeyboard = inlineKeyboard ?? (await buildClientMenuKeyboard(ctx));
+  const extra = buildCombinedMenuMarkup(replyKeyboard, resolvedInlineKeyboard);
+
   try {
-    return await ctx.reply(text, buildKeyboard());
+    return await ctx.reply(text, extra);
   } catch (error) {
     if (!ctx.chat?.id) {
       throw error;
     }
 
     try {
-      return await ctx.telegram.sendMessage(ctx.chat.id, text, buildKeyboard());
+      return await ctx.telegram.sendMessage(ctx.chat.id, text, extra);
     } catch {
       throw error;
     }
@@ -57,8 +112,12 @@ export const sendClientMenuToChat = async (
   chatId: number,
   text: string = DEFAULT_MENU_PROMPT,
 ): Promise<Message.TextMessage | undefined> => {
+  const replyKeyboard = buildKeyboard();
+  const inlineKeyboard = buildInlineMenuKeyboard();
+  const extra = buildCombinedMenuMarkup(replyKeyboard, inlineKeyboard);
+
   try {
-    return await telegram.sendMessage(chatId, text, buildKeyboard());
+    return await telegram.sendMessage(chatId, text, extra);
   } catch {
     return undefined;
   }

--- a/tests/keyboard-guard.test.js
+++ b/tests/keyboard-guard.test.js
@@ -18,18 +18,19 @@ ensureEnv('SUPPORT_USERNAME', 'test_support');
 ensureEnv('SUPPORT_URL', 'https://t.me/test_support');
 ensureEnv('WEBHOOK_DOMAIN', 'example.com');
 ensureEnv('WEBHOOK_SECRET', 'secret');
+ensureEnv('HMAC_SECRET', 'secret');
+ensureEnv('REDIS_URL', 'redis://localhost:6379');
 
-const { CLIENT_MENU } = require('../src/ui/clientMenu');
+const { CLIENT_MENU_TRIGGER } = require('../src/ui/clientMenu');
 const { keyboardGuard } = require('../src/bot/middlewares/keyboardGuard');
-const { promptClientSupport } = require('../src/bot/flows/client/support');
 
-test('keyboardGuard allows clients to reach support prompt', async () => {
+test('keyboardGuard allows clients to reach the menu trigger', async () => {
 
   const replies = [];
 
   const ctx = {
     chat: { id: 42, type: 'private' },
-    message: { text: CLIENT_MENU.support },
+    message: { text: CLIENT_MENU_TRIGGER },
     auth: {
       user: {
         role: 'client',
@@ -48,12 +49,10 @@ test('keyboardGuard allows clients to reach support prompt', async () => {
 
   await guard(ctx, async () => {
     nextCalled = true;
-    await promptClientSupport(ctx);
   });
 
-  assert.equal(nextCalled, true, 'Client support text should reach the next middleware');
-  assert.equal(replies.length, 1, 'Client should receive the support prompt reply');
-  assert.match(replies[0], /^🆘 Связаться с поддержкой\./, 'Support prompt should be shown');
+  assert.equal(nextCalled, true, 'Client menu trigger should reach the next middleware');
+  assert.equal(replies.length, 0, 'Guard should not send additional replies for clients');
 });
 
 test('keyboardGuard blocks executors from client support menu', async () => {
@@ -61,7 +60,7 @@ test('keyboardGuard blocks executors from client support menu', async () => {
 
   const ctx = {
     chat: { id: 43, type: 'private' },
-    message: { text: CLIENT_MENU.support },
+    message: { text: CLIENT_MENU_TRIGGER },
     auth: {
       user: {
         role: 'executor',


### PR DESCRIPTION
## Summary
- Replace the client reply keyboard with a single “🎯 Меню” button and build the inline client menu keyboard from one place for replies and callbacks.
- Update the client menu flow to reuse the inline keyboard, handle the new trigger, and remove legacy text listeners from the taxi and delivery flows.
- Refresh the keyboard guard test data and related wiring to recognise the new client menu trigger.

## Testing
- node --test tests/keyboard-guard.test.js
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68df98a829cc832da4c4bddc592ca9e4