### PR TITLE
Add safe callback handling for orders channel

### DIFF
--- a/src/bot/services/feedback.ts
+++ b/src/bot/services/feedback.ts
@@ -2,7 +2,15 @@ import { logger } from '../../config';
 import { copy } from '../copy';
 import type { BotContext } from '../types';
 
-export const sendProcessingFeedback = async (ctx: BotContext): Promise<void> => {
+interface ProcessingFeedbackOptions {
+  skipAnswerCbQuery?: boolean;
+}
+
+export const sendProcessingFeedback = async (
+  ctx: BotContext,
+  options?: ProcessingFeedbackOptions,
+): Promise<void> => {
+  const skipAnswerCbQuery = options?.skipAnswerCbQuery ?? false;
   const chatId = ctx.chat?.id ?? (ctx.callbackQuery && 'message' in ctx.callbackQuery
     ? ctx.callbackQuery.message?.chat?.id
     : undefined);
@@ -15,7 +23,7 @@ export const sendProcessingFeedback = async (ctx: BotContext): Promise<void> => 
     }
   }
 
-  if (typeof ctx.answerCbQuery === 'function' && ctx.callbackQuery) {
+  if (!skipAnswerCbQuery && typeof ctx.answerCbQuery === 'function' && ctx.callbackQuery) {
     try {
       await ctx.answerCbQuery(copy.waiting);
     } catch (error) {

--- a/src/bot/utils/callbacks.ts
+++ b/src/bot/utils/callbacks.ts
@@ -1,0 +1,48 @@
+import type { BotContext } from '../types';
+import { logger } from '../../config';
+
+export type AnswerCbQueryOptions = Parameters<NonNullable<BotContext['answerCbQuery']>>[1];
+
+const ensureFallbackText = (text?: string): string =>
+  text && text.trim().length > 0 ? text : 'Не удалось обработать действие. Попробуйте ещё раз.';
+
+const sendFallbackMessage = async (ctx: BotContext, text?: string): Promise<void> => {
+  const fallbackText = ensureFallbackText(text);
+  const recipientId = ctx.from?.id;
+
+  if (typeof recipientId === 'number') {
+    try {
+      await ctx.telegram.sendMessage(recipientId, fallbackText);
+      return;
+    } catch (error) {
+      logger.warn({ err: error, recipientId }, 'Failed to send callback fallback via direct message');
+    }
+  }
+
+  if (typeof ctx.reply === 'function') {
+    try {
+      await ctx.reply(fallbackText);
+      return;
+    } catch (error) {
+      logger.warn({ err: error }, 'Failed to send callback fallback via reply');
+    }
+  }
+};
+
+export const answerCallbackQuerySafely = async (
+  ctx: BotContext,
+  text?: string,
+  options?: AnswerCbQueryOptions,
+): Promise<void> => {
+  if (typeof ctx.answerCbQuery !== 'function') {
+    await sendFallbackMessage(ctx, text);
+    return;
+  }
+
+  try {
+    await ctx.answerCbQuery(text, options);
+  } catch (error) {
+    logger.warn({ err: error, userId: ctx.from?.id }, 'Failed to answer callback query');
+    await sendFallbackMessage(ctx, text);
+  }
+};

--- a/tests/orders-channel-callback-fallback.test.ts
+++ b/tests/orders-channel-callback-fallback.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { BotContext } from '../src/bot/types';
+
+const ensureEnv = (key: string, value: string): void => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+const ensureBotEnv = (): void => {
+  ensureEnv('BOT_TOKEN', 'test-bot-token');
+  ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+  ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+  ensureEnv('KASPI_NAME', 'Test User');
+  ensureEnv('KASPI_PHONE', '+70000000000');
+  ensureEnv('SUPPORT_USERNAME', 'test_support');
+  ensureEnv('SUPPORT_URL', 'https://t.me/test_support');
+  ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+  ensureEnv('WEBHOOK_SECRET', 'secret');
+  ensureEnv('HMAC_SECRET', 'secret');
+  ensureEnv('REDIS_URL', 'redis://localhost:6379');
+};
+
+test('callback fallback is sent when query already answered', async () => {
+  ensureBotEnv();
+  const { sendProcessingFeedback } = await import('../src/bot/services/feedback');
+  const { answerCallbackQuerySafely } = await import('../src/bot/utils/callbacks');
+
+  let answerCalls = 0;
+  const delivered: Array<{ chatId: number; text: string }> = [];
+
+  const ctx = {
+    from: { id: 777 },
+    chat: { id: 888, type: 'private' },
+    callbackQuery: {
+      id: 'cbq:1',
+      chat_instance: 'instance',
+      from: { id: 777 },
+      message: { message_id: 321, chat: { id: 888, type: 'private' } },
+      data: 'noop',
+    },
+    telegram: {
+      sendChatAction: async () => {},
+      sendMessage: async (chatId: number, text: string) => {
+        delivered.push({ chatId, text });
+        return { message_id: 999 } as unknown;
+      },
+    },
+    answerCbQuery: async () => {
+      answerCalls += 1;
+      if (answerCalls === 2) {
+        throw new Error('QUERY_ID_INVALID');
+      }
+      return true;
+    },
+  } as unknown as BotContext;
+
+  await sendProcessingFeedback(ctx);
+  await answerCallbackQuerySafely(ctx, 'Готово');
+
+  assert.equal(answerCalls, 2);
+  assert.deepStrictEqual(delivered, [{ chatId: 777, text: 'Готово' }]);
+});


### PR DESCRIPTION
## Summary
- wrap orders channel callback responses in a safe helper that falls back to direct messages when Telegram rejects the callback answer
- allow `sendProcessingFeedback` to skip provisional callback answers for show_alert scenarios to avoid double responses
- add a regression test covering the "callback already confirmed" case to ensure the fallback path is used

## Testing
- node --test -r ts-node/register/transpile-only tests/orders-channel-callback-fallback.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfe9e6e6e4832d8cf6caf93c039fac