### PR TITLE
Enforce 2GIS-only address inputs

### DIFF
--- a/src/bot/flows/client/taxiOrderFlow.ts
+++ b/src/bot/flows/client/taxiOrderFlow.ts
@@ -1,8 +1,5 @@
 import { Telegraf } from 'telegraf';
-import type {
-  InlineKeyboardMarkup,
-  Location as TelegramLocation,
-} from 'telegraf/typings/core/types/typegram';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
 import { publishOrderToDriversChannel, type PublishOrderStatus } from '../../channels/ordersChannel';
 import { logger } from '../../../config';
@@ -14,11 +11,7 @@ import {
   resetClientOrderDraft,
   type CompletedOrderDraft,
 } from '../../services/orders';
-import {
-  geocodeOrderLocation,
-  geocodeTelegramLocation,
-  isTwoGisLink,
-} from '../../services/geocode';
+import * as geocode from '../../services/geocode';
 import { estimateTaxiPrice, formatPriceAmount } from '../../services/pricing';
 import { clearInlineKeyboard } from '../../services/cleanup';
 import { ensurePrivateCallback, isPrivateChat } from '../../services/access';
@@ -68,7 +61,7 @@ const TAXI_RECENT_DROPOFF_ACTION_PATTERN = new RegExp(
 const getDraft = (ctx: BotContext): ClientOrderDraftState => ctx.session.client.taxi;
 
 const TAXI_STEP_ID = 'client:taxi:step';
-const TAXI_MANUAL_ADDRESS_HINT_STEP_ID = 'client:taxi:hint:manual-address';
+const TAXI_ADDRESS_REQUIREMENT_STEP_ID = 'client:taxi:hint:manual-address';
 const TAXI_CONFIRMATION_HINT_STEP_ID = 'client:taxi:hint:confirmation';
 const TAXI_GEOCODE_ERROR_STEP_ID = 'client:taxi:error:geocode';
 const TAXI_CANCELLED_STEP_ID = 'client:taxi:cancelled';
@@ -96,9 +89,8 @@ const updateTaxiStep = async (
 };
 
 const ADDRESS_INPUT_HINTS = [
-  '• Отправьте ссылку 2ГИС на точку или организацию (поддерживаются /geo и /firm).',
-  '• Поделитесь геопозицией через Telegram (скрепка → «Геопозиция»).',
-  '• Введите адрес вручную — внимательно проверьте город, улицу и дом.',
+  '• Нажмите «Открыть 2ГИС», выберите точку или организацию и отправьте ссылку (/geo или /firm).',
+  '• Ручной ввод адреса и геопозиции Telegram больше не принимаются — отправьте ссылку из 2ГИС.',
 ] as const;
 
 const buildAddressPrompt = (lines: string[]): string =>
@@ -107,10 +99,10 @@ const buildAddressPrompt = (lines: string[]): string =>
 const buildTwoGisShortcutKeyboard = (city: AppCity): InlineKeyboardMarkup =>
   buildUrlKeyboard('🗺 Открыть 2ГИС', dgBase(city));
 
-const remindManualAddressAccuracy = async (ctx: BotContext): Promise<void> => {
+const remindTwoGisRequirement = async (ctx: BotContext): Promise<void> => {
   await ui.step(ctx, {
-    id: TAXI_MANUAL_ADDRESS_HINT_STEP_ID,
-    text: '⚠️ При ручном вводе адреса укажите город, улицу и дом. Если есть ссылка 2ГИС или геопозиция, отправьте её.',
+    id: TAXI_ADDRESS_REQUIREMENT_STEP_ID,
+    text: '⚠️ Принимаем только ссылки 2ГИС. Нажмите «Открыть 2ГИС», выберите точку и отправьте ссылку на неё.',
     cleanup: true,
   });
 };
@@ -213,7 +205,7 @@ const requestDropoffAddress = async (
 const handleGeocodingFailure = async (ctx: BotContext): Promise<void> => {
   await ui.step(ctx, {
     id: TAXI_GEOCODE_ERROR_STEP_ID,
-    text: 'Не удалось распознать адрес. Укажите лучше на карте или через 2ГИС.',
+    text: 'Не удалось распознать ссылку 2ГИС. Откройте 2ГИС ещё раз и пришлите ссылку на нужную точку.',
     cleanup: true,
   });
 };
@@ -292,16 +284,17 @@ const applyDropoffDetails = async (
 };
 
 const applyPickupAddress = async (ctx: BotContext, draft: ClientOrderDraftState, text: string) => {
-  const pickup = await geocodeOrderLocation(text, { city: ctx.session.city });
+  if (!geocode.isTwoGisLink(text)) {
+    await remindTwoGisRequirement(ctx);
+    return;
+  }
+
+  const pickup = await geocode.geocodeOrderLocation(text, { city: ctx.session.city });
   if (!pickup) {
     await handleGeocodingFailure(ctx);
     return;
   }
   await applyPickupDetails(ctx, draft, pickup);
-
-  if (!isTwoGisLink(text)) {
-    await remindManualAddressAccuracy(ctx);
-  }
 };
 
 const buildConfirmationKeyboard = () =>
@@ -335,43 +328,16 @@ const applyDropoffAddress = async (
   draft: ClientOrderDraftState,
   text: string,
 ): Promise<void> => {
-  const dropoff = await geocodeOrderLocation(text, { city: ctx.session.city });
+  if (!geocode.isTwoGisLink(text)) {
+    await remindTwoGisRequirement(ctx);
+    return;
+  }
+
+  const dropoff = await geocode.geocodeOrderLocation(text, { city: ctx.session.city });
   if (!dropoff) {
     await handleGeocodingFailure(ctx);
     return;
   }
-  await applyDropoffDetails(ctx, draft, dropoff);
-
-  if (!isTwoGisLink(text)) {
-    await remindManualAddressAccuracy(ctx);
-  }
-};
-
-const applyPickupLocation = async (
-  ctx: BotContext,
-  draft: ClientOrderDraftState,
-  location: TelegramLocation,
-): Promise<void> => {
-  const pickup = await geocodeTelegramLocation(location, { label: 'Геопозиция подачи' });
-  if (!pickup) {
-    await handleGeocodingFailure(ctx);
-    return;
-  }
-
-  await applyPickupDetails(ctx, draft, pickup);
-};
-
-const applyDropoffLocation = async (
-  ctx: BotContext,
-  draft: ClientOrderDraftState,
-  location: TelegramLocation,
-): Promise<void> => {
-  const dropoff = await geocodeTelegramLocation(location, { label: 'Геопозиция назначения' });
-  if (!dropoff) {
-    await handleGeocodingFailure(ctx);
-    return;
-  }
-
   await applyDropoffDetails(ctx, draft, dropoff);
 };
 
@@ -633,10 +599,10 @@ const handleIncomingLocation = async (
 
   switch (draft.stage) {
     case 'collectingPickup':
-      await applyPickupLocation(ctx, draft, message.location);
+      await remindTwoGisRequirement(ctx);
       return;
     case 'collectingDropoff':
-      await applyDropoffLocation(ctx, draft, message.location);
+      await remindTwoGisRequirement(ctx);
       return;
     case 'awaitingConfirmation':
       await remindConfirmationActions(ctx);
@@ -648,6 +614,13 @@ const handleIncomingLocation = async (
 
 const resolveTaxiCity = (ctx: BotContext): AppCity | undefined =>
   ctx.session.city ?? ctx.auth.user.citySelected ?? undefined;
+
+export const taxiOrderTestables = {
+  applyPickupAddress,
+  applyDropoffAddress,
+  handleIncomingLocation,
+  remindTwoGisRequirement,
+};
 
 const resumeTaxiFlowStep = async (ctx: BotContext): Promise<boolean> => {
   const draft = getDraft(ctx);
@@ -779,7 +752,7 @@ const handleRecentPickup = async (ctx: BotContext, locationId: string): Promise<
   } catch (error) {
     logger.warn(
       { err: error, city, userId: ctx.auth.user.telegramId, locationId },
-      'Failed to resolve recent taxi pickup location; falling back to manual input',
+      'Failed to resolve recent taxi pickup location; continuing without suggestion',
     );
   }
   if (!location) {
@@ -814,7 +787,7 @@ const handleRecentDropoff = async (ctx: BotContext, locationId: string): Promise
   } catch (error) {
     logger.warn(
       { err: error, city, userId: ctx.auth.user.telegramId, locationId },
-      'Failed to resolve recent taxi dropoff location; falling back to manual input',
+      'Failed to resolve recent taxi dropoff location; continuing without suggestion',
     );
   }
   if (!location) {

--- a/tests/address-input-rules.test.js
+++ b/tests/address-input-rules.test.js
@@ -1,0 +1,299 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+const ensureEnv = (key, value) => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+const ensureBotEnv = () => {
+  ensureEnv('BOT_TOKEN', 'test-bot-token');
+  ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+  ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+  ensureEnv('KASPI_NAME', 'Test User');
+  ensureEnv('KASPI_PHONE', '+70000000000');
+  ensureEnv('SUPPORT_USERNAME', 'test_support');
+  ensureEnv('SUPPORT_URL', 'https://t.me/test_support');
+  ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+  ensureEnv('WEBHOOK_SECRET', 'secret');
+  ensureEnv('HMAC_SECRET', 'secret');
+  ensureEnv('REDIS_URL', 'redis://localhost:6379');
+};
+
+const createTaxiContext = (draft) => ({
+  chat: { id: 101, type: 'private' },
+  session: {
+    city: 'almaty',
+    client: {
+      taxi: draft,
+      delivery: { stage: 'idle' },
+    },
+  },
+  auth: {
+    user: {
+      telegramId: 555,
+      citySelected: 'almaty',
+    },
+  },
+  telegram: {},
+});
+
+const createDeliveryContext = (draft) => ({
+  chat: { id: 202, type: 'private' },
+  session: {
+    city: 'almaty',
+    client: {
+      taxi: { stage: 'idle' },
+      delivery: draft,
+    },
+  },
+  auth: {
+    user: {
+      telegramId: 777,
+      citySelected: 'almaty',
+    },
+  },
+  telegram: {},
+});
+
+const stubUi = (t) => {
+  const { ui } = require('../src/bot/ui');
+  const calls = [];
+  const originalStep = ui.step;
+  const originalClear = ui.clear;
+
+  ui.step = async (_ctx, options) => {
+    calls.push({ id: options.id, text: options.text });
+    return { messageId: 1, sent: true };
+  };
+  ui.clear = async () => {};
+
+  t.after(() => {
+    ui.step = originalStep;
+    ui.clear = originalClear;
+  });
+
+  return calls;
+};
+
+const stubDb = (t) => {
+  const db = require('../src/db');
+  const originalQuery = db.pool.query;
+  db.pool.query = async () => ({ rows: [] });
+  t.after(() => {
+    db.pool.query = originalQuery;
+  });
+};
+
+test('taxi flow rejects plain text addresses', { concurrency: false }, async (t) => {
+  ensureBotEnv();
+
+  const uiCalls = stubUi(t);
+  stubDb(t);
+
+  const geocode = require('../src/bot/services/geocode');
+  const originalGeocode = geocode.geocodeOrderLocation;
+  let geocodeCalls = 0;
+  geocode.geocodeOrderLocation = async () => {
+    geocodeCalls += 1;
+    return null;
+  };
+  t.after(() => {
+    geocode.geocodeOrderLocation = originalGeocode;
+  });
+
+  const { taxiOrderTestables } = require('../src/bot/flows/client/taxiOrderFlow');
+
+  const draft = { stage: 'collectingPickup' };
+  const ctx = createTaxiContext(draft);
+
+  await taxiOrderTestables.applyPickupAddress(ctx, draft, 'ул. Абая, 1');
+
+  assert.equal(draft.stage, 'collectingPickup');
+  assert.equal(geocodeCalls, 0);
+  assert.ok(
+    uiCalls.some(
+      (call) =>
+        call.id === 'client:taxi:hint:manual-address' &&
+        /ссылк/iu.test(call.text) &&
+        /2ГИС/iu.test(call.text),
+    ),
+    'manual text should trigger 2GIS requirement reminder',
+  );
+});
+
+test('taxi flow rejects Telegram locations', { concurrency: false }, async (t) => {
+  ensureBotEnv();
+
+  const uiCalls = stubUi(t);
+
+  const { taxiOrderTestables } = require('../src/bot/flows/client/taxiOrderFlow');
+
+  const draft = { stage: 'collectingPickup' };
+  const ctx = createTaxiContext(draft);
+  ctx.message = { location: { latitude: 43.256, longitude: 76.945 } };
+
+  let nextCalled = false;
+  await taxiOrderTestables.handleIncomingLocation(ctx, async () => {
+    nextCalled = true;
+  });
+
+  assert.equal(draft.stage, 'collectingPickup');
+  assert.equal(nextCalled, false);
+  assert.ok(
+    uiCalls.some(
+      (call) =>
+        call.id === 'client:taxi:hint:manual-address' &&
+        /ссылк/iu.test(call.text) &&
+        /2ГИС/iu.test(call.text),
+    ),
+    'location input should trigger 2GIS requirement reminder',
+  );
+});
+
+test('taxi flow accepts 2GIS links', { concurrency: false }, async (t) => {
+  ensureBotEnv();
+
+  const uiCalls = stubUi(t);
+  stubDb(t);
+
+  const geocode = require('../src/bot/services/geocode');
+  const originalGeocode = geocode.geocodeOrderLocation;
+  const location = {
+    query: '2ГИС точка',
+    address: 'Алматы, Абая 1',
+    latitude: 43.256,
+    longitude: 76.945,
+    twoGisUrl: 'https://2gis.kz/almaty/geo/70000001000000000',
+  };
+  geocode.geocodeOrderLocation = async () => location;
+  t.after(() => {
+    geocode.geocodeOrderLocation = originalGeocode;
+  });
+
+  const { taxiOrderTestables } = require('../src/bot/flows/client/taxiOrderFlow');
+
+  const draft = { stage: 'collectingPickup' };
+  const ctx = createTaxiContext(draft);
+
+  await taxiOrderTestables.applyPickupAddress(
+    ctx,
+    draft,
+    'https://2gis.kz/almaty/geo/70000001000000000?queryState=point',
+  );
+
+  assert.equal(draft.stage, 'collectingDropoff');
+  assert.deepEqual(draft.pickup, location);
+  assert.ok(
+    uiCalls.some((call) => call.id === 'client:taxi:step' && /Теперь отправьте пункт назначения/iu.test(call.text)),
+    'successful pickup should request dropoff point',
+  );
+});
+
+test('delivery flow rejects plain text addresses', { concurrency: false }, async (t) => {
+  ensureBotEnv();
+
+  const uiCalls = stubUi(t);
+  stubDb(t);
+
+  const geocode = require('../src/bot/services/geocode');
+  const originalGeocode = geocode.geocodeOrderLocation;
+  let geocodeCalls = 0;
+  geocode.geocodeOrderLocation = async () => {
+    geocodeCalls += 1;
+    return null;
+  };
+  t.after(() => {
+    geocode.geocodeOrderLocation = originalGeocode;
+  });
+
+  const { deliveryOrderTestables } = require('../src/bot/flows/client/deliveryOrderFlow');
+
+  const draft = { stage: 'collectingPickup' };
+  const ctx = createDeliveryContext(draft);
+
+  await deliveryOrderTestables.applyPickupAddress(ctx, draft, 'проспект Достык, 1');
+
+  assert.equal(draft.stage, 'collectingPickup');
+  assert.equal(geocodeCalls, 0);
+  assert.ok(
+    uiCalls.some(
+      (call) =>
+        call.id === 'client:delivery:hint:manual-address' &&
+        /ссылк/iu.test(call.text) &&
+        /2ГИС/iu.test(call.text),
+    ),
+    'manual text should trigger 2GIS requirement reminder',
+  );
+});
+
+test('delivery flow rejects Telegram locations', { concurrency: false }, async (t) => {
+  ensureBotEnv();
+
+  const uiCalls = stubUi(t);
+
+  const { deliveryOrderTestables } = require('../src/bot/flows/client/deliveryOrderFlow');
+
+  const draft = { stage: 'collectingPickup' };
+  const ctx = createDeliveryContext(draft);
+  ctx.message = { location: { latitude: 43.256, longitude: 76.945 } };
+
+  let nextCalled = false;
+  await deliveryOrderTestables.handleIncomingLocation(ctx, async () => {
+    nextCalled = true;
+  });
+
+  assert.equal(draft.stage, 'collectingPickup');
+  assert.equal(nextCalled, false);
+  assert.ok(
+    uiCalls.some(
+      (call) =>
+        call.id === 'client:delivery:hint:manual-address' &&
+        /ссылк/iu.test(call.text) &&
+        /2ГИС/iu.test(call.text),
+    ),
+    'location input should trigger 2GIS requirement reminder',
+  );
+});
+
+test('delivery flow accepts 2GIS links', { concurrency: false }, async (t) => {
+  ensureBotEnv();
+
+  const uiCalls = stubUi(t);
+  stubDb(t);
+
+  const geocode = require('../src/bot/services/geocode');
+  const originalGeocode = geocode.geocodeOrderLocation;
+  const location = {
+    query: '2ГИС склад',
+    address: 'Алматы, Назарбаева 10',
+    latitude: 43.25,
+    longitude: 76.92,
+    twoGisUrl: 'https://2gis.kz/almaty/firm/70000001000000001',
+  };
+  geocode.geocodeOrderLocation = async () => location;
+  t.after(() => {
+    geocode.geocodeOrderLocation = originalGeocode;
+  });
+
+  const { deliveryOrderTestables } = require('../src/bot/flows/client/deliveryOrderFlow');
+
+  const draft = { stage: 'collectingPickup' };
+  const ctx = createDeliveryContext(draft);
+
+  await deliveryOrderTestables.applyPickupAddress(
+    ctx,
+    draft,
+    'https://2gis.kz/almaty/firm/70000001000000001?queryState=firm',
+  );
+
+  assert.equal(draft.stage, 'collectingDropoff');
+  assert.deepEqual(draft.pickup, location);
+  assert.ok(
+    uiCalls.some((call) => call.id === 'client:delivery:step' && /Адрес доставки/iu.test(call.text)),
+    'successful pickup should request dropoff address details',
+  );
+});


### PR DESCRIPTION
## Summary
- update taxi and delivery client flows to require 2GIS links and refresh customer-facing hints
- reject manual text and Telegram geolocation inputs with a dedicated reminder message
- add regression tests covering accepted 2GIS links and rejected inputs for both flows

## Testing
- node --test tests/address-input-rules.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e053831a98832da02bdf74dbb8d11b