### PR TITLE
Track manual executor subscription payment requests

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -58,6 +58,7 @@ const createSubscriptionState = (): ExecutorFlowState['subscription'] => ({
   status: 'idle',
   selectedPeriodId: undefined,
   pendingPaymentId: undefined,
+  paymentRequestedAt: undefined,
   moderationChatId: undefined,
   moderationMessageId: undefined,
   lastInviteLink: undefined,

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -85,6 +85,9 @@ export const startExecutorSubscription = async (
     return;
   }
 
+  state.subscription.status = 'await_payment_manual';
+  state.subscription.paymentRequestedAt = Date.now();
+
   await ui.step(ctx, {
     id: SUBSCRIPTION_INFO_STEP_ID,
     text: buildSubscriptionInfoText(ctx),

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -58,6 +58,14 @@ const createVerificationState = (): ExecutorVerificationState => {
 
 const createSubscriptionState = (): ExecutorSubscriptionState => ({
   status: 'idle',
+  selectedPeriodId: undefined,
+  pendingPaymentId: undefined,
+  paymentRequestedAt: undefined,
+  moderationChatId: undefined,
+  moderationMessageId: undefined,
+  lastInviteLink: undefined,
+  lastIssuedAt: undefined,
+  lastReminderAt: undefined,
 });
 
 const EXECUTOR_JOB_STAGES: readonly ExecutorJobsState['stage'][] = [

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -148,6 +148,7 @@ export interface ExecutorVerificationRoleState {
 export type ExecutorSubscriptionStatus =
   | 'idle'
   | 'selectingPeriod'
+  | 'await_payment_manual'
   | 'awaitingReceipt'
   | 'pendingModeration';
 
@@ -155,6 +156,7 @@ export interface ExecutorSubscriptionState {
   status: ExecutorSubscriptionStatus;
   selectedPeriodId?: string;
   pendingPaymentId?: string;
+  paymentRequestedAt?: number | Date;
   moderationChatId?: number;
   moderationMessageId?: number;
   lastInviteLink?: string;


### PR DESCRIPTION
## Summary
- allow executor subscription state to include a manual payment pending status and timestamp
- set the new status and timestamp when prompting executors for subscription payments
- ensure session initialisation preserves the extended subscription fields for persistence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e062f0ef70832dbc67c1175c4fd0fd