### PR TITLE
Update executor subscription messaging

### DIFF
--- a/src/bot/ui.ts
+++ b/src/bot/ui.ts
@@ -1,3 +1,4 @@
+import { Markup } from 'telegraf';
 import type {
   InlineKeyboardMarkup,
   LinkPreviewOptions,
@@ -5,7 +6,7 @@ import type {
   ReplyKeyboardMarkup,
 } from 'telegraf/typings/core/types/typegram';
 
-import { logger } from '../config';
+import { config, logger } from '../config';
 import { pool } from '../db';
 import { updateFlowMeta } from '../db/sessions';
 import { mergeInlineKeyboards, buildInlineKeyboard } from './keyboards/common';
@@ -15,6 +16,9 @@ import { bindInlineKeyboardToUser } from './services/callbackTokens';
 import { copy } from './copy';
 
 const HOME_BUTTON_LABEL = copy.home;
+
+export const contactModeratorBtn = () =>
+  Markup.button.url('📤 Отправить чек', config.support.url);
 
 export interface FlowRecoveryDescriptor {
   type: string;

--- a/tests/executor-plan-durations.test.js
+++ b/tests/executor-plan-durations.test.js
@@ -10,6 +10,7 @@ const ensureEnv = (key, value) => {
 };
 
 ensureEnv('BOT_TOKEN', 'test-bot-token');
+ensureEnv('HMAC_SECRET', 'test-hmac');
 ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
 ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
 ensureEnv('KASPI_NAME', 'Test User');
@@ -18,6 +19,7 @@ ensureEnv('SUPPORT_USERNAME', 'test_support');
 ensureEnv('SUPPORT_URL', 'https://t.me/test_support');
 ensureEnv('WEBHOOK_DOMAIN', 'example.com');
 ensureEnv('WEBHOOK_SECRET', 'secret');
+ensureEnv('REDIS_URL', 'redis://localhost:6379');
 
 const executorPlans = require('../src/domain/executorPlans');
 const subscriptionPlans = require('../src/bot/flows/executor/subscriptionPlans');
@@ -66,4 +68,6 @@ test('custom plan durations propagate through subscription prompts', (t) => {
   const keyboard = subscriptionFlow.__private__.buildSubscriptionKeyboard();
   const planLabels = keyboard.inline_keyboard.slice(0, 3).map((row) => row[0].text);
   assert.deepEqual(planLabels, ['10 дней', '21 день', '45 дней']);
+  assert.equal(keyboard.inline_keyboard[3][0].text, '📤 Отправить чек');
+  assert.equal(keyboard.inline_keyboard[3][0].url, 'https://t.me/test_support');
 });


### PR DESCRIPTION
## Summary
- rewrite the executor subscription info text with numbered HTML-formatted steps and explicit support link
- add a reusable “📤 Отправить чек” button wired to the configured support URL and include it in the subscription keyboard
- extend the subscription flow test harness to cover the new button and provide the required environment stubs

## Testing
- node --test tests/executor-plan-durations.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e06d23b304832da3dd9460fd1729a2