### PR TITLE
Add manual payment tracking metadata to executor subscriptions

### DIFF
--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -156,7 +156,7 @@ export interface ExecutorSubscriptionState {
   status: ExecutorSubscriptionStatus;
   selectedPeriodId?: string;
   pendingPaymentId?: string;
-  paymentRequestedAt?: number | Date;
+  paymentRequestedAt?: number;
   moderationChatId?: number;
   moderationMessageId?: number;
   lastInviteLink?: string;


### PR DESCRIPTION
## Summary
- extend executor subscription state to include a `paymentRequestedAt` timestamp for manual payments
- normalise restored subscription state so status and timestamps remain valid across persistence layers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e06d2aaca8832d8f19eef2c9e909ef