### PR TITLE
Handle protocol-less 2GIS URLs in extractPreferredUrl

### DIFF
--- a/src/lib/extractPreferredUrl.ts
+++ b/src/lib/extractPreferredUrl.ts
@@ -1,4 +1,5 @@
-const URL_PATTERN = /https?:\/\/[^\s]+/giu;
+const URL_PATTERN =
+  /(?:https?:\/\/[^\s]+|(?:https?:\/\/)?(?:[\w.-]+\.)?2gis\.[^\/\s]+\/\S+)/giu;
 const TRAILING_PUNCTUATION_RE = /[)\]\}>,.!?:;'"«»„“”›‹…]+$/u;
 
 const stripTrailingPunctuation = (value: string): string => {
@@ -36,9 +37,13 @@ export const extractPreferredUrl = (value: string): string | null => {
 
   const matches: string[] = [];
   for (const match of value.matchAll(URL_PATTERN)) {
-    const cleaned = stripTrailingPunctuation(match[0]);
+    let cleaned = stripTrailingPunctuation(match[0]);
     if (!isMeaningfulUrl(cleaned)) {
       continue;
+    }
+
+    if (!/^\w[\w+.-]*:\/\//u.test(cleaned)) {
+      cleaned = `https://${cleaned}`;
     }
 
     matches.push(cleaned);

--- a/tests/address-input-rules.test.js
+++ b/tests/address-input-rules.test.js
@@ -3,6 +3,8 @@ const assert = require('node:assert/strict');
 
 require('ts-node/register/transpile-only');
 
+const { extractPreferredUrl } = require('../src/lib/extractPreferredUrl');
+
 const ensureEnv = (key, value) => {
   if (!process.env[key]) {
     process.env[key] = value;
@@ -296,4 +298,20 @@ test('delivery flow accepts 2GIS links', { concurrency: false }, async (t) => {
     uiCalls.some((call) => call.id === 'client:delivery:step' && /Адрес доставки/iu.test(call.text)),
     'successful pickup should request dropoff address details',
   );
+});
+
+test('extractPreferredUrl adds protocol to bare 2GIS link in text', () => {
+  const text = 'Название 2gis.kz/almaty/geo/70000001000000000';
+
+  const result = extractPreferredUrl(text);
+
+  assert.equal(result, 'https://2gis.kz/almaty/geo/70000001000000000');
+});
+
+test('extractPreferredUrl handles go.2gis short link without protocol', () => {
+  const text = 'Ссылка go.2gis.com/redirect?some=value&utm=1';
+
+  const result = extractPreferredUrl(text);
+
+  assert.equal(result, 'https://go.2gis.com/redirect?some=value&utm=1');
 });


### PR DESCRIPTION
## Summary
- extend the preferred URL extractor to match 2GIS links even when no protocol is provided
- normalize protocol-less matches to https so downstream consumers receive valid URLs
- add unit coverage for bare 2gis.kz and go.2gis.com links without protocols

## Testing
- node --test tests/address-input-rules.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e42e36ef34832daf935078fb3ae6a3