### PR TITLE
Handle failures when rendering client orders list

### DIFF
--- a/src/bot/flows/client/orders.ts
+++ b/src/bot/flows/client/orders.ts
@@ -40,7 +40,7 @@ import {
   ORDER_KIND_LABELS,
 } from '../../orders/formatting';
 
-type ClientOrdersFailureScope = 'list' | 'detail' | 'status' | 'cancel';
+type ClientOrdersFailureScope = 'list' | 'detail' | 'status' | 'cancel' | 'render';
 
 const handleClientOrdersFailure = async (
   ctx: BotContext,
@@ -283,13 +283,18 @@ export const renderOrdersList = async (
   const text = buildOrdersListText(items);
   const keyboard = buildOrdersListKeyboard(items);
 
-  await ui.step(ctx, {
-    id: CLIENT_ORDERS_LIST_STEP_ID,
-    text,
-    keyboard,
-    homeAction: CLIENT_MENU_ACTION,
-    recovery: { type: 'client:orders:list' },
-  });
+  try {
+    await ui.step(ctx, {
+      id: CLIENT_ORDERS_LIST_STEP_ID,
+      text,
+      keyboard,
+      homeAction: CLIENT_MENU_ACTION,
+      recovery: { type: 'client:orders:list' },
+    });
+  } catch (error) {
+    await handleClientOrdersFailure(ctx, 'render', error);
+    return null;
+  }
 
   return items;
 };

--- a/tests/client-orders-render-failure.test.js
+++ b/tests/client-orders-render-failure.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node/register/transpile-only');
+
+const ensureEnv = (key, value) => {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+};
+
+const ensureBotEnv = () => {
+  ensureEnv('BOT_TOKEN', 'test-bot-token');
+  ensureEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/db');
+  ensureEnv('KASPI_CARD', '0000 0000 0000 0000');
+  ensureEnv('KASPI_NAME', 'Test User');
+  ensureEnv('KASPI_PHONE', '+70000000000');
+  ensureEnv('SUPPORT_USERNAME', 'test_support');
+  ensureEnv('SUPPORT_URL', 'https://t.me/test_support');
+  ensureEnv('WEBHOOK_DOMAIN', 'example.com');
+  ensureEnv('WEBHOOK_SECRET', 'secret');
+  ensureEnv('HMAC_SECRET', 'secret');
+  ensureEnv('REDIS_URL', 'redis://localhost:6379');
+};
+
+test('renderOrdersList falls back when UI rendering fails', async () => {
+  ensureBotEnv();
+
+  const { copy } = require('../src/bot/copy');
+  const uiModulePath = require.resolve('../src/bot/ui');
+  const ordersModulePath = require.resolve('../src/bot/flows/client/orders');
+
+  delete require.cache[ordersModulePath];
+
+  const uiModule = require(uiModulePath);
+  const originalUiStep = uiModule.ui.step;
+  const originalUiClear = uiModule.ui.clear;
+  uiModule.ui.step = async () => {
+    throw new Error('ui-step-failure');
+  };
+  uiModule.ui.clear = async () => {};
+
+  try {
+    const { renderOrdersList } = require(ordersModulePath);
+
+    const replies = [];
+    const ctx = {
+      auth: { user: { telegramId: 123 } },
+      chat: { id: 456, type: 'private' },
+      reply: async (text) => {
+        replies.push(text);
+      },
+      telegram: {
+        deleteMessage: async () => {},
+      },
+      session: {},
+    };
+
+    const result = await renderOrdersList(ctx, []);
+    assert.equal(result, null, 'renderOrdersList should return null when rendering fails');
+    assert.equal(replies.length, 1, 'fallback reply should be sent');
+    assert.equal(replies[0], copy.serviceUnavailable, 'fallback reply should inform about service unavailability');
+  } finally {
+    uiModule.ui.step = originalUiStep;
+    uiModule.ui.clear = originalUiClear;
+    delete require.cache[ordersModulePath];
+  }
+});


### PR DESCRIPTION
## Summary
- guard the client orders list renderer so UI errors surface a friendly fallback instead of silently failing
- expand the failure scope tracking for client order flows to include rendering issues
- add a regression test covering the render failure path to ensure users receive a service message when list rendering breaks

## Testing
- node --test tests/client-orders-processing-feedback.test.js tests/client-orders-render-failure.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e42b3ed0a4832d99359dd02dcec753