### PR TITLE
Improve 2GIS link handling and client order updates

### DIFF
--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -24,7 +24,11 @@ import { buildInlineKeyboard, mergeInlineKeyboards } from '../keyboards/common';
 import { wrapCallbackData } from '../services/callbackTokens';
 import { copy } from '../copy';
 import { sendClientMenuToChat } from '../../ui/clientMenu';
-import { buildOrderContactKeyboard, buildOrderDetailText } from '../orders/formatting';
+import {
+  buildOrderContactKeyboard,
+  buildOrderDetailText,
+  formatExecutorLabel,
+} from '../orders/formatting';
 import {
   reportOrderClaimed,
   reportOrderCompleted,
@@ -195,14 +199,19 @@ const notifyClientAboutOrderUpdate = async (
 ): Promise<void> => {
   const intro = introText.trim();
   const fallbackText = intro || CLIENT_ORDER_UPDATE_FALLBACK_TEXT;
+  let introLine = intro;
   let messageText = fallbackText;
   const messageOptions: { reply_markup?: InlineKeyboardMarkup } = {};
 
   try {
     const detailedOrder = await getOrderWithExecutorById(orderId);
     if (detailedOrder) {
+      if (detailedOrder.status === 'claimed') {
+        const executorLine = `👤 Исполнитель: ${formatExecutorLabel(detailedOrder)}.`;
+        introLine = introLine ? `${introLine}\n${executorLine}` : executorLine;
+      }
       const detailText = stripControlReminder(buildOrderDetailText(detailedOrder, {}));
-      messageText = intro ? `${intro}\n\n${detailText}` : detailText;
+      messageText = introLine ? `${introLine}\n\n${detailText}` : detailText;
 
       const contactKeyboard = buildOrderContactKeyboard(detailedOrder);
       if (contactKeyboard) {

--- a/src/bot/services/geocoding.ts
+++ b/src/bot/services/geocoding.ts
@@ -452,8 +452,18 @@ const parse2GisLink = async (value: string): Promise<Parsed2GisLink | null> => {
 };
 
 export const isTwoGisLink = (value: string): boolean => {
-  const url = parseUrl(value);
-  return Boolean(url && is2GisHostname(url.hostname));
+  const directUrl = parseUrl(value);
+  if (directUrl && is2GisHostname(directUrl.hostname)) {
+    return true;
+  }
+
+  const extracted = extractPreferredUrl(value);
+  if (!extracted) {
+    return false;
+  }
+
+  const extractedUrl = parseUrl(extracted);
+  return Boolean(extractedUrl && is2GisHostname(extractedUrl.hostname));
 };
 
 interface TwoGisPoint {

--- a/src/utils/2gis.ts
+++ b/src/utils/2gis.ts
@@ -9,3 +9,22 @@ export const dgPointLink = (city: AppCity, query: string): string =>
 
 export const dgABLink = (city: AppCity, from: string, to: string): string =>
   `${buildBase(city)}/directions/points/${encodeURIComponent(from)}~${encodeURIComponent(to)}`;
+
+export const extractTwoGisCitySlug = (value: string | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    const segments = url.pathname
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0);
+
+    const [first] = segments;
+    return first ? first.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- allow client address flows to accept labelled 2GIS links and reject locations from other cities
- show detailed order cards after order creation and include executor information in client updates
- add shared 2GIS helpers and tests covering the new address validation logic

## Testing
- node --test tests/address-input-rules.test.js
- node --test tests/orders-client-notifications.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4c62e0624832db9b60e446186e391