### PR TITLE
Improve geocoding resilience and client flow UX

### DIFF
--- a/src/bot/services/geocoding.ts
+++ b/src/bot/services/geocoding.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config';
-import { extractPreferredUrl } from '../../lib/extractPreferredUrl';
+import { extractPreferredUrl, removeUrls } from '../../lib/extractPreferredUrl';
 
 export interface GeocodingResult {
   query: string;
@@ -1098,7 +1098,9 @@ export const geocodeAddress = async (
   const extractedUrl = extractPreferredUrl(trimmed);
   const preferredTwoGisUrl = extractedUrl && isTwoGisLink(extractedUrl) ? extractedUrl : null;
 
-  const normalizedQuery = normaliseQuery(trimmed);
+  const rawNormalizedQuery = normaliseQuery(trimmed);
+  const strippedQuery = removeUrls(trimmed);
+  const normalizedQuery = strippedQuery ? normaliseQuery(strippedQuery) : rawNormalizedQuery;
   const cityName = options.cityName?.trim();
   const searchQuery = buildCityAwareQuery(normalizedQuery, cityName);
 

--- a/src/bot/services/orders.ts
+++ b/src/bot/services/orders.ts
@@ -25,6 +25,25 @@ export const resetClientOrderDraft = (draft: ClientOrderDraftState): void => {
   draft.entrance = undefined;
   draft.floor = undefined;
   draft.recipientPhone = undefined;
+  draft.lastFailedGeocodeStage = undefined;
+  draft.geocodeFailureCount = undefined;
+};
+
+export type GeocodeStage = 'pickup' | 'dropoff';
+
+export const recordGeocodeFailure = (
+  draft: ClientOrderDraftState,
+  stage: GeocodeStage,
+): number => {
+  const nextCount = draft.lastFailedGeocodeStage === stage ? (draft.geocodeFailureCount ?? 0) + 1 : 1;
+  draft.lastFailedGeocodeStage = stage;
+  draft.geocodeFailureCount = nextCount;
+  return nextCount;
+};
+
+export const clearGeocodeFailures = (draft: ClientOrderDraftState): void => {
+  draft.lastFailedGeocodeStage = undefined;
+  draft.geocodeFailureCount = undefined;
 };
 
 export const isOrderDraftComplete = (

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -216,6 +216,8 @@ export interface ClientOrderDraftState {
   entrance?: string;
   floor?: string;
   recipientPhone?: string;
+  lastFailedGeocodeStage?: 'pickup' | 'dropoff';
+  geocodeFailureCount?: number;
 }
 
 export interface ClientFlowState {

--- a/src/lib/extractPreferredUrl.ts
+++ b/src/lib/extractPreferredUrl.ts
@@ -26,45 +26,87 @@ const isMeaningfulUrl = (value: string): boolean => {
   return !(lower === 'http://' || lower === 'https://');
 };
 
+const ensureAbsoluteUrl = (value: string): string =>
+  /^\w[\w+.-]*:\/\//u.test(value) ? value : `https://${value}`;
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+
+interface UrlCandidate {
+  raw: string;
+  cleaned: string;
+  normalized: string;
+}
+
+const collectUrlCandidates = (value: string): UrlCandidate[] => {
+  if (!value) {
+    return [];
+  }
+
+  const candidates: UrlCandidate[] = [];
+  for (const match of value.matchAll(URL_PATTERN)) {
+    const raw = match[0];
+    const cleaned = stripTrailingPunctuation(raw);
+    if (!isMeaningfulUrl(cleaned)) {
+      continue;
+    }
+
+    const normalized = ensureAbsoluteUrl(cleaned);
+    candidates.push({ raw, cleaned, normalized });
+  }
+
+  return candidates;
+};
+
 /**
  * Extracts the most relevant URL from a free-form text value.
  * Prefers 2ГИС links when present and removes trailing punctuation.
  */
 export const extractPreferredUrl = (value: string): string | null => {
-  if (!value) {
+  const candidates = collectUrlCandidates(value);
+  if (candidates.length === 0) {
     return null;
   }
 
-  const matches: string[] = [];
-  for (const match of value.matchAll(URL_PATTERN)) {
-    let cleaned = stripTrailingPunctuation(match[0]);
-    if (!isMeaningfulUrl(cleaned)) {
-      continue;
-    }
-
-    if (!/^\w[\w+.-]*:\/\//u.test(cleaned)) {
-      cleaned = `https://${cleaned}`;
-    }
-
-    matches.push(cleaned);
-  }
-
-  if (matches.length === 0) {
-    return null;
-  }
-
-  for (const candidate of matches) {
+  for (const candidate of candidates) {
     try {
-      const hostname = new URL(candidate).hostname;
+      const hostname = new URL(candidate.normalized).hostname;
       if (/2gis\./iu.test(hostname)) {
-        return candidate;
+        return candidate.normalized;
       }
     } catch {
       // Ignore parsing errors and try the next candidate.
     }
   }
 
-  return matches[0];
+  return candidates[0]?.normalized ?? null;
+};
+
+export const removeUrls = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  let result = value;
+  const seen = new Set<string>();
+
+  for (const candidate of collectUrlCandidates(value)) {
+    const variations = [candidate.raw];
+    if (candidate.cleaned !== candidate.raw) {
+      variations.push(candidate.cleaned);
+    }
+
+    for (const variation of variations) {
+      if (!variation || seen.has(variation)) {
+        continue;
+      }
+
+      seen.add(variation);
+      const pattern = new RegExp(escapeRegExp(variation), 'giu');
+      result = result.replace(pattern, ' ');
+    }
+  }
+
+  return result.replace(/\s+/gu, ' ').trim();
 };
 
 export default extractPreferredUrl;


### PR DESCRIPTION
## Summary
- tighten URL parsing by extracting canonical 2GIS links and removing embedded URLs before geocoding
- add retry-aware geocoding errors, city validation, and distance checks to client delivery and taxi flows
- persist geocoding retry state so successful attempts reset failure counters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea638385f0832dbc5ebea6f24b84ac