### PR TITLE
Add migration to backfill missing order_status enum values

### DIFF
--- a/db/migrations/0101_add_missing_order_statuses.down.sql
+++ b/db/migrations/0101_add_missing_order_statuses.down.sql
@@ -1,0 +1,2 @@
+-- Cannot remove values from PostgreSQL enums safely.
+-- This down migration is intentionally left blank.

--- a/db/migrations/0101_add_missing_order_statuses.up.sql
+++ b/db/migrations/0101_add_missing_order_statuses.up.sql
@@ -1,0 +1,2 @@
+ALTER TYPE public.order_status ADD VALUE IF NOT EXISTS 'new';
+ALTER TYPE public.order_status ADD VALUE IF NOT EXISTS 'expired';


### PR DESCRIPTION
## Summary
- add a migration that ensures the `order_status` enum contains the `new` and `expired` values so queries and updates no longer fail

## Testing
- not run (migration only)


------
https://chatgpt.com/codex/tasks/task_e_68eb1e23b078832da536adf1866adb7e