### PR TITLE
Improve executor order completion UX

### DIFF
--- a/src/bot/flows/client/orders.ts
+++ b/src/bot/flows/client/orders.ts
@@ -99,7 +99,7 @@ const CLIENT_ORDER_STEP_IDS = [
   CLIENT_ORDER_STATUS_STEP_ID,
 ];
 
-const ACTIVE_ORDER_STATUSES: OrderStatus[] = ['new', 'open', 'claimed'];
+const ACTIVE_ORDER_STATUSES: OrderStatus[] = ['new', 'open', 'claimed', 'in_progress'];
 
 const ORDER_AGAIN_ACTION: Record<OrderWithExecutor['kind'], string> = {
   taxi: CLIENT_TAXI_ORDER_AGAIN_ACTION,
@@ -168,7 +168,7 @@ const renderOrderStatus = async (
   }
 
   const status = formatStatusLabel(order.status);
-  const emoji = order.status === 'claimed' ? '🚗' : '⏳';
+  const emoji = order.status === 'claimed' || order.status === 'in_progress' ? '🚗' : '⏳';
   const { text, reply_markup } = buildStatusMessage(
     emoji,
     `Заказ №${order.shortId}: ${status.full}.`,
@@ -284,6 +284,7 @@ export const renderOrdersList = async (
   const keyboard = buildOrdersListKeyboard(items);
 
   try {
+    await ui.clear(ctx, { ids: CLIENT_ORDERS_LIST_STEP_ID, cleanupOnly: false });
     await ui.step(ctx, {
       id: CLIENT_ORDERS_LIST_STEP_ID,
       text,

--- a/src/bot/orders/formatting.ts
+++ b/src/bot/orders/formatting.ts
@@ -19,6 +19,7 @@ const ORDER_STATUS_TEXT: Record<OrderStatus, { short: string; full: string }> = 
   new: { short: 'обрабатывается', full: 'Обрабатывается оператором' },
   open: { short: 'ожидает исполнителя', full: 'Ожидает исполнителя' },
   claimed: { short: 'в работе', full: 'Выполняется исполнителем' },
+  in_progress: { short: 'в работе', full: 'Исполнитель подтвердил начало выполнения' },
   cancelled: { short: 'отменён', full: 'Заказ отменён' },
   finished: { short: 'завершён', full: 'Заказ выполнен' },
   expired: { short: 'истёк', full: 'Срок выполнения истёк' },
@@ -60,7 +61,7 @@ const normalisePhoneNumber = (phone: string): string => phone.replace(/[\s()-]/g
 export const buildOrderContactKeyboard = (
   order: OrderWithExecutor,
 ): InlineKeyboardMarkup | undefined => {
-  if (order.status !== 'claimed') {
+  if (order.status !== 'claimed' && order.status !== 'in_progress') {
     return undefined;
   }
 

--- a/src/db/orders.ts
+++ b/src/db/orders.ts
@@ -423,7 +423,7 @@ export const tryReleaseOrder = async (
           claimed_at = NULL,
           channel_message_id = NULL,
           updated_at = now()
-      WHERE id = $1 AND status = 'claimed' AND claimed_by = $2
+      WHERE id = $1 AND status = ANY('{claimed,in_progress}'::order_status[]) AND claimed_by = $2
       RETURNING *
     `,
     [id, claimedBy],
@@ -479,7 +479,7 @@ export const tryCompleteOrder = async (
       SET status = 'finished',
           completed_at = now(),
           updated_at = now()
-      WHERE id = $1 AND status = 'claimed' AND claimed_by = $2
+      WHERE id = $1 AND status = ANY('{claimed,in_progress}'::order_status[]) AND claimed_by = $2
       RETURNING *
     `,
     [id, claimedBy],
@@ -620,10 +620,10 @@ export const findActiveOrderForExecutor = async (
 
 export const listExecutorOrders = async (
   executorId: number,
-  statuses: OrderStatus[] = ['open', 'claimed'],
+  statuses: OrderStatus[] = ['claimed', 'in_progress'],
   limit = 20,
 ): Promise<OrderRecord[]> => {
-  const statusFilter = statuses.length > 0 ? statuses : ['open', 'claimed'];
+  const statusFilter = statuses.length > 0 ? statuses : ['claimed', 'in_progress'];
   const params: unknown[] = [executorId, statusFilter];
   if (limit && Number.isFinite(limit) && limit > 0) {
     params.push(Math.trunc(limit));

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -6,6 +6,7 @@ export type OrderStatus =
   | 'new'
   | 'open'
   | 'claimed'
+  | 'in_progress'
   | 'cancelled'
   | 'finished'
   | 'expired';


### PR DESCRIPTION
## Summary
- ensure the client orders list is always refreshed and treat in-progress requests as active
- extend the executor order workflow with a persistent control step, contact/address actions, and richer completion handling
- allow executors to finish in-progress orders and expose the new status throughout formatting utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eb8c87eecc832d867b4f6a51eb456e