### PR TITLE
Add runtime audit tooling for Telegram bot silence

### DIFF
--- a/docs/bot-audit.md
+++ b/docs/bot-audit.md
@@ -1,0 +1,62 @@
+# Bot runtime audit
+
+The `npm run bot:audit` script performs a series of connectivity and configuration
+checks that commonly cause the Telegram bot to stop responding. It is intended to
+be run from the production shell (with the same environment variables used by the
+service) and gives immediate feedback about missing dependencies or webhook
+misconfiguration.
+
+## Prerequisites
+
+Before running the audit, export the environment variables that the bot normally
+requires (see `src/config/env.ts` for the full list). At a minimum you will need:
+
+- `BOT_TOKEN`
+- `DATABASE_URL`
+- `REDIS_URL`
+- `WEBHOOK_DOMAIN`
+- `WEBHOOK_SECRET`
+
+The script talks directly to Telegram and the backing services, so make sure the
+network from which you execute it can reach PostgreSQL, Redis and api.telegram.org.
+
+## Usage
+
+```bash
+npm run bot:audit
+```
+
+The command prints an emoji-prefixed summary for each check. A green tick means
+the check passed, a warning triangle highlights something that needs attention,
+and a red cross indicates a blocking problem.
+
+## Checks performed
+
+- **Database connection** — Executes `SELECT now()` through the pool. Failure indicates the bot cannot reach PostgreSQL, which causes degraded behaviour and missed replies.
+- **Redis connection** — Pings the configured Redis instance. Without Redis the session cache and queues stop progressing and conversations appear frozen.
+- **Telegram bot token** — Calls `getMe` to ensure the token is valid. If the token was revoked or rotated without updating the environment, the bot goes silent immediately.
+- **Telegram webhook** — Confirms that the webhook URL matches `WEBHOOK_DOMAIN/WEBHOOK_SECRET` and reports pending updates plus Telegram-side errors. A mismatch means Telegram is delivering updates to a different endpoint.
+- **Telegram getUpdates backlog** — Attempts to poll updates. A `409 Conflict` means webhook mode is active (expected). Any other response is printed so you can see if updates are piling up because the webhook was disabled.
+
+Warnings emitted by the webhook check include pending update counts and the last
+error timestamps reported by Telegram. Use these hints to investigate whether the
+bot endpoint is reachable from Telegram.
+
+## Typical remediation steps
+
+*Database or Redis errors* — verify credentials, firewall rules and SSL
+requirements. The script reuses the same connection options as the bot, so the
+output should guide you to the misconfigured service.
+
+*Webhook mismatch* — reconfigure the load balancer or run the deployment pipeline
+that exposes the correct domain. After fixing the routing, rerun the audit and
+confirm that the webhook URL and pending update count return to normal.
+
+*Pending Telegram updates* — if the webhook URL is correct but pending updates
+keep growing, inspect the bot logs for HTTP 5xx responses. Clearing the queue with
+`deleteWebhook({ drop_pending_updates: true })` may be necessary after the
+underlying issue is fixed.
+
+*Token check failures* — create a new bot token via BotFather and update the
+environment variables, then run the audit again.
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "node dist/index.js",
     "db:migrate": "dbmate --migrations-dir=db/migrations --wait",
     "ctr:report": "node dist/scripts/ctrReport.js",
-    "lint:unused": "ts-prune --exit"
+    "lint:unused": "ts-prune --exit",
+    "bot:audit": "ts-node --transpile-only src/scripts/botAudit.ts"
   },
   "dependencies": {
     "@sentry/node": "^7.120.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { openApiHandler } from './http/docs';
 import { registerSpaOrderRoutes } from './http/spaOrders';
 import { registerJobs, stopJobs } from './jobs';
 import { initSentry } from './infra/sentry';
+import { buildWebhookConfig } from './utils/webhook';
 
 const gracefulShutdownErrorPatterns = [
   /bot is not running/i,
@@ -68,20 +69,6 @@ const isGracefulShutdownError = (error: unknown): boolean => {
   }
 
   return matchesGracefulShutdownMessage(error.message);
-};
-
-const removeTrailingSlashes = (value: string): string => value.replace(/\/+$/, '');
-
-const buildWebhookConfig = (
-  domain: string,
-  secret: string,
-): { path: string; url: string } => {
-  const trimmedDomain = removeTrailingSlashes(domain);
-  const path = `/bot/${secret}`;
-  return {
-    path,
-    url: `${trimmedDomain}${path}`,
-  };
 };
 
 const parsePort = (value: string | undefined): number => {

--- a/src/scripts/botAudit.ts
+++ b/src/scripts/botAudit.ts
@@ -1,0 +1,215 @@
+import process from 'node:process';
+import { Telegraf } from 'telegraf';
+
+import { config } from '../config';
+import { pool } from '../db';
+import { closeRedisClient, getRedisClient } from '../infra/redis';
+import { buildWebhookConfig } from '../utils/webhook';
+
+type CheckStatus = 'ok' | 'warn' | 'error';
+
+interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  message: string;
+  details?: string;
+}
+
+interface CheckSuccessResult {
+  status?: Extract<CheckStatus, 'ok' | 'warn'>;
+  message: string;
+}
+
+type CheckHandler = () => Promise<string | CheckSuccessResult>;
+
+const results: CheckResult[] = [];
+
+const normaliseSuccess = (value: string | CheckSuccessResult): CheckSuccessResult =>
+  typeof value === 'string' ? { status: 'ok', message: value } : value;
+
+const normaliseError = (error: unknown): { message: string; details?: string } => {
+  if (error instanceof Error) {
+    return {
+      message: `${error.name}: ${error.message}`,
+      details: error.stack,
+    };
+  }
+
+  return {
+    message: typeof error === 'string' ? error : JSON.stringify(error),
+  };
+};
+
+const runCheck = async (name: string, handler: CheckHandler): Promise<void> => {
+  try {
+    const { status = 'ok', message } = normaliseSuccess(await handler());
+    results.push({ name, status, message });
+  } catch (error) {
+    const { message, details } = normaliseError(error);
+    results.push({ name, status: 'error', message, details });
+  }
+};
+
+const formatTimestamp = (value: number | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value * 1000);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return date.toISOString();
+};
+
+const run = async (): Promise<void> => {
+  await runCheck('Database connection', async () => {
+    const { rows } = await pool.query<{ now: Date }>('SELECT now() AS now');
+    const serverTime = rows[0]?.now instanceof Date ? rows[0].now.toISOString() : String(rows[0]?.now);
+    return `Connected (server time: ${serverTime ?? 'unknown'})`;
+  });
+
+  await runCheck('Redis connection', async () => {
+    const redis = getRedisClient();
+    if (!redis) {
+      return { status: 'warn', message: 'Redis is not configured; session cache and queues are disabled.' };
+    }
+
+    try {
+      await redis.connect();
+      const response = await redis.ping();
+      return `Ping response: ${response}`;
+    } finally {
+      await closeRedisClient();
+    }
+  });
+
+  const telegramClient = new Telegraf(config.bot.token, { handlerTimeout: 10_000 });
+  const telegram = telegramClient.telegram;
+
+  await runCheck('Telegram bot token', async () => {
+    const me = await telegram.getMe();
+    const username = me.username ? `@${me.username}` : me.first_name ?? 'unknown';
+    return `Authenticated as ${username} (id: ${me.id})`;
+  });
+
+  await runCheck('Telegram webhook', async () => {
+    const info = await telegram.getWebhookInfo();
+    const { url } = buildWebhookConfig(config.webhook.domain, config.webhook.secret);
+
+    const expectedUrl = url;
+    const registeredUrl = info.url || '(not set)';
+
+    if (!info.url) {
+      throw new Error(`No webhook registered. Expected ${expectedUrl}`);
+    }
+
+    if (info.url !== expectedUrl) {
+      throw new Error(`Webhook mismatch. Expected ${expectedUrl}, got ${registeredUrl}`);
+    }
+
+    const extraNotes: string[] = [];
+    if (info.pending_update_count > 0) {
+      extraNotes.push(`pending updates: ${info.pending_update_count}`);
+    }
+
+    const lastError = formatTimestamp(info.last_error_date);
+    if (lastError && info.last_error_message) {
+      extraNotes.push(`last error at ${lastError}: ${info.last_error_message}`);
+    } else if (lastError) {
+      extraNotes.push(`last error at ${lastError}`);
+    }
+
+    const lastSyncError = formatTimestamp(info.last_synchronization_error_date);
+    if (lastSyncError) {
+      extraNotes.push(`last sync error at ${lastSyncError}`);
+    }
+
+    const message = extraNotes.length > 0
+      ? `Webhook is registered correctly (${registeredUrl}); ${extraNotes.join('; ')}`
+      : `Webhook is registered correctly (${registeredUrl})`;
+
+    const status: CheckStatus = info.pending_update_count > 0 || lastError || lastSyncError ? 'warn' : 'ok';
+
+    return { status, message };
+  });
+
+  await runCheck('Telegram getUpdates backlog', async () => {
+    try {
+      const updates = await telegram.getUpdates(0, 1, 0, undefined);
+      if (updates.length > 0) {
+        return {
+          status: 'warn',
+          message: `There are ${updates.length} updates waiting in long polling queue. Webhook may be disabled.`,
+        };
+      }
+
+      return 'No pending updates in long polling queue';
+    } catch (error) {
+      const candidate = error as {
+        code?: unknown;
+        response?: { error_code?: unknown; description?: unknown };
+        description?: unknown;
+      };
+
+      const errorCode =
+        typeof candidate?.code === 'number'
+          ? candidate.code
+          : typeof candidate?.response?.error_code === 'number'
+            ? candidate.response.error_code
+            : undefined;
+
+      if (errorCode === 409) {
+        return {
+          status: 'ok',
+          message: 'Webhook mode is active (getUpdates is unavailable by design).',
+        };
+      }
+
+      throw error;
+    }
+  });
+
+  await telegramClient.stop();
+
+  try {
+    await pool.end();
+  } catch (error) {
+    const { message } = normaliseError(error);
+    results.push({ name: 'Database pool shutdown', status: 'warn', message });
+  }
+
+  const hasErrors = results.some((result) => result.status === 'error');
+
+  for (const result of results) {
+    const prefix =
+      result.status === 'ok'
+        ? '✅'
+        : result.status === 'warn'
+          ? '⚠️'
+          : '❌';
+    // eslint-disable-next-line no-console
+    console.log(`${prefix} ${result.name}: ${result.message}`);
+    if (result.details) {
+      // eslint-disable-next-line no-console
+      console.log(result.details);
+    }
+  }
+
+  if (hasErrors) {
+    process.exitCode = 1;
+  }
+};
+
+run().catch((error) => {
+  const { message, details } = normaliseError(error);
+  // eslint-disable-next-line no-console
+  console.error(`❌ Audit failed: ${message}`);
+  if (details) {
+    // eslint-disable-next-line no-console
+    console.error(details);
+  }
+  process.exit(1);
+});
+

--- a/src/utils/webhook.ts
+++ b/src/utils/webhook.ts
@@ -1,0 +1,15 @@
+export const removeTrailingSlashes = (value: string): string => value.replace(/\/+$/, '');
+
+export const buildWebhookConfig = (
+  domain: string,
+  secret: string,
+): { path: string; url: string } => {
+  const trimmedDomain = removeTrailingSlashes(domain);
+  const path = `/bot/${secret}`;
+
+  return {
+    path,
+    url: `${trimmedDomain}${path}`,
+  };
+};
+


### PR DESCRIPTION
## Summary
- add a `bot:audit` script that validates the database, redis and Telegram webhook configuration
- extract webhook URL helpers for reuse between the runtime and audit script
- document how to run the audit and interpret common failure modes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ebdc8e4bbc832dac3b427c08e7e92c