### PR TITLE
Gracefully handle missing order coordinates

### DIFF
--- a/src/bot/keyboards/orders.ts
+++ b/src/bot/keyboards/orders.ts
@@ -3,7 +3,7 @@ import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram'
 import type { OrderLocation } from '../../types';
 import type { AppCity } from '../../domain/cities';
 import { build2GisLink } from '../../utils/location';
-import { dgABLink } from '../../utils/2gis';
+import { dgABLink, dgPointLink } from '../../utils/2gis';
 import { buildInlineKeyboard } from './common';
 
 export interface OrderLocationsKeyboardOptions {
@@ -12,37 +12,65 @@ export interface OrderLocationsKeyboardOptions {
   routeLabel?: string;
 }
 
+const isValidCoordinate = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const resolveLocationUrl = (city: AppCity, location: OrderLocation): string => {
+  const directUrl = location.twoGisUrl?.trim();
+  if (directUrl) {
+    return directUrl;
+  }
+
+  if (isValidCoordinate(location.latitude) && isValidCoordinate(location.longitude)) {
+    try {
+      return build2GisLink(location.latitude, location.longitude, {
+        query: location.address,
+        city,
+      });
+    } catch {
+      // fall through to the query-based link below
+    }
+  }
+
+  const query = location.query?.trim() || location.address;
+  return dgPointLink(city, query);
+};
+
+const resolveRouteUrl = (city: AppCity, pickup: OrderLocation, dropoff: OrderLocation): string | undefined => {
+  const from = pickup.query?.trim() || pickup.address;
+  const to = dropoff.query?.trim() || dropoff.address;
+
+  if (!from || !to) {
+    return undefined;
+  }
+
+  return dgABLink(city, from, to);
+};
+
 export const buildOrderLocationsKeyboard = (
   city: AppCity,
   pickup: OrderLocation,
   dropoff: OrderLocation,
   options: OrderLocationsKeyboardOptions = {},
 ): InlineKeyboardMarkup => {
-  const pickupUrl =
-    pickup.twoGisUrl && pickup.twoGisUrl.length > 0
-      ? pickup.twoGisUrl
-      : build2GisLink(pickup.latitude, pickup.longitude, {
-          query: pickup.address,
-          city,
-        });
-  const dropoffUrl =
-    dropoff.twoGisUrl && dropoff.twoGisUrl.length > 0
-      ? dropoff.twoGisUrl
-      : build2GisLink(dropoff.latitude, dropoff.longitude, {
-          query: dropoff.address,
-          city,
-        });
+  const pickupUrl = resolveLocationUrl(city, pickup);
+  const dropoffUrl = resolveLocationUrl(city, dropoff);
 
   const pickupLabel = options.pickupLabel ?? '🅰️ Открыть в 2ГИС (A)';
   const dropoffLabel = options.dropoffLabel ?? '🅱️ Открыть в 2ГИС (B)';
   const routeLabel = options.routeLabel ?? '➡️ Маршрут (2ГИС)';
-  const routeUrl = dgABLink(city, pickup.query, dropoff.query);
+  const routeUrl = resolveRouteUrl(city, pickup, dropoff);
 
-  return buildInlineKeyboard([
+  const rows: { label: string; url: string }[][] = [
     [
       { label: pickupLabel, url: pickupUrl },
       { label: dropoffLabel, url: dropoffUrl },
     ],
-    [{ label: routeLabel, url: routeUrl }],
-  ]);
+  ];
+
+  if (routeUrl) {
+    rows.push([{ label: routeLabel, url: routeUrl }]);
+  }
+
+  return buildInlineKeyboard(rows);
 };


### PR DESCRIPTION
## Summary
- fall back to 2ГИС search links when order coordinates are missing or invalid
- skip rendering the route button when there is no usable address data

## Testing
- not run (TypeScript build takes too long in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ebf00671b8832d806f9a1adac30a01