### PR TITLE
Add migration for finished order status

### DIFF
--- a/db/migrations/0103_add_finished_status.down.sql
+++ b/db/migrations/0103_add_finished_status.down.sql
@@ -1,0 +1,2 @@
+-- Cannot remove values from PostgreSQL enums safely.
+-- This down migration is intentionally left blank.

--- a/db/migrations/0103_add_finished_status.up.sql
+++ b/db/migrations/0103_add_finished_status.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE public.order_status ADD VALUE IF NOT EXISTS 'finished';


### PR DESCRIPTION
## Summary
- add migration to ensure the `finished` order status exists in production enums

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebf60cb460832d8a6b672448145398